### PR TITLE
Fix ipfamily classification

### DIFF
--- a/backends/nft/nft.go
+++ b/backends/nft/nft.go
@@ -279,7 +279,7 @@ func Callback(ch <-chan *client.ServiceEndpoints) {
 			}
 
 			// dispatch group chain (ie: dnat_net_0a002700 for 10.0.39.x and a /24 mask)
-			if set.v6 == (clusterIP.To4() == nil) {
+			if set.v6 == (len(clusterIP) == net.IPv6len) {
 				// this family owns the cluster IP => build the dispatch chain
 				mask := ipv4Mask
 				if set.v6 {

--- a/pkg/api/localnetv1/ipset.go
+++ b/pkg/api/localnetv1/ipset.go
@@ -34,7 +34,7 @@ func (set *IPSet) Add(s string) (ip net.IP) {
 		return
 	}
 
-	if ip.To4() == nil {
+	if len(ip) == net.IPv6len {
 		insertString(&set.V6, s)
 	} else {
 		insertString(&set.V4, s)


### PR DESCRIPTION
The `net.To4` could convert an IPv6 address to an IPv4 address.
Using `To4` could cause IPv6 addresses wrongly classified as IPv4 ones.

More details in https://github.com/golang/go/blob/189c6946f598dc668946499e4179775c06295f9d/src/net/ip.go#L209-L222

Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>