### PR TITLE
Add a "version" command

### DIFF
--- a/cmd/kpng/main.go
+++ b/cmd/kpng/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"runtime/pprof"
 
@@ -31,6 +32,7 @@ import (
 
 var (
 	cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
+	version    = "(unknown)"
 )
 
 func main() {
@@ -46,6 +48,7 @@ func main() {
 		kube2storeCmd(),
 		file2storeCmd(),
 		api2storeCmd(),
+		versionCmd(),
 	)
 
 	if err := cmd.Execute(); err != nil {
@@ -76,4 +79,14 @@ func setupGlobal() (ctx context.Context) {
 	}
 
 	return
+}
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print the version and quit",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version)
+		},
+	}
 }


### PR DESCRIPTION
Adds;
```
kpng version
```
The `main.version` string is defined at compile time using `-X main.version=(something)`. Example;

```
CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags '-static' -X main.version=$(git rev-parse --short HEAD)" -o kpng ./cmd/kpng
```
Now the git commit is printed;
```bash
$ ./kpng version
95df644
```

When developing when the commit is not updated a `date` may be more useful;
```
CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags '-static' -X main.version=$(date +%F:%T)" -o kpng ./cmd/kpng
./kpng version
2021-05-11:11:20:36
```

**NOTE**; I have deliberately made the printout clean. No "Kpng version:" prefix or something. The version will most likely be interpreted by some script or test-report tool and unnecessary decorations are just annoying. And humans understand it just as good.

