### PR TITLE
kpng-local-up: use main instead of master

### DIFF
--- a/hack/kpng-local-up.sh
+++ b/hack/kpng-local-up.sh
@@ -15,9 +15,8 @@ function setup_k8s {
         mkdir -p $HOME/go/
         export GOPATH=$HOME/go
         # need kind 0.11 bc 0.10 has a bug w/ kubeproxy=none
-        GO111MODULE="on" go get sigs.k8s.io/kind@master
-        chmod 755 $GOPATH/bin/kind
-        cp $GOPATH/bin/kind /usr/local/bin/kind
+        GO111MODULE="on" go get sigs.k8s.io/kind@main
+        export PATH="$(go env GOPATH)/bin:${PATH}"
     fi
     kind version
 


### PR DESCRIPTION
Currently in kind project there is no master branch, there is main.
This patch updates the code to the new branch and also use
export command to replace chmod/cp which are not needed.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>