### PR TITLE
Adding NodePort service support for IPVS backend

### DIFF
--- a/backends/ipvs-as-sink/flags.go
+++ b/backends/ipvs-as-sink/flags.go
@@ -1,0 +1,41 @@
+package ipvssink
+
+import (
+	"net"
+
+	"github.com/spf13/pflag"
+)
+
+func (s *Backend) BindFlags(flags *pflag.FlagSet) {
+	s.Config.BindFlags(flags)
+
+	// real ipvs sink flags
+	flags.BoolVar(&s.dryRun, "dry-run", false, "dry run (print instead of applying)")
+	flags.StringSliceVar(&s.nodeAddresses, "node-address", interfaceAddresses(), "A comma-separated list of IPs to associate when using NodePort type. Defaults to all the Node addresses")
+	flags.StringVar(&s.schedulingMethod, "scheduling-method", "rr", "Algorithm for allocating TCP conn & UDP datagrams to real servers. Values: rr,wrr,lc,wlc,lblc,lblcr,dh,sh,seq,nq")
+	flags.Int32Var(&s.weight, "weight", 1, "An integer specifying the capacity of server relative to others in the pool")
+
+}
+
+func interfaceAddresses() []string {
+	ifacesAddress, err := net.InterfaceAddrs()
+	if err != nil {
+		panic(err)
+	}
+
+	var addresses []string
+	for _, addr := range ifacesAddress {
+		// TODO: Ignore interfaces in PodCIDR or ClusterCIDR
+		ip, _, err := net.ParseCIDR(addr.String())
+		if err != nil {
+			panic(err)
+		}
+		// I want to deal only with IPv4 right now...
+		if ipv4 := ip.To4(); ipv4 == nil {
+			continue
+		}
+
+		addresses = append(addresses, ip.String())
+	}
+	return addresses
+}

--- a/backends/ipvs-as-sink/helpers.go
+++ b/backends/ipvs-as-sink/helpers.go
@@ -6,6 +6,12 @@ import (
 	"sigs.k8s.io/kpng/pkg/api/localnetv1"
 )
 
+const (
+	ClusterIPService    = "ClusterIP"
+	NodePortService     = "NodePort"
+	LoadBalancerService = "LoadBalancer"
+)
+
 func asDummyIPs(set *localnetv1.IPSet) (ips []string) {
 	ips = make([]string, 0, len(set.V4)+len(set.V6))
 
@@ -21,4 +27,35 @@ func asDummyIPs(set *localnetv1.IPSet) (ips []string) {
 
 func epPortSuffix(port *localnetv1.PortMapping) string {
 	return port.Protocol.String() + ":" + strconv.Itoa(int(port.Port))
+}
+
+func diffInPortMapping(previous, current *localnetv1.Service) (added, removed []*localnetv1.PortMapping) {
+	for _, p1 := range previous.Ports {
+		found := false
+		for _, p2 := range current.Ports {
+			if p1.Name == p2.Name && p1.Port == p2.Port && p1.Protocol == p2.Protocol {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			removed = append(removed, p1)
+		}
+	}
+
+	for _, p1 := range current.Ports {
+		found := false
+		for _, p2 := range previous.Ports {
+			if p1.Name == p2.Name && p1.Port == p2.Port && p1.Protocol == p2.Protocol {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			added = append(added, p1)
+		}
+	}
+	return
 }


### PR DESCRIPTION
Other changes:
* Made scheduling method and weight as configurable param
* Fixes related to Service Update in IPVS backend
    a) whenever service is updated with new portMapping(port,
       protocol,targetPort) , EP will be added under new IPVS LB IP

    b) whenever service is update where a portMapping is removed, EP entry
       related to that protocol/port will be deleted.