### PR TITLE
ClusterIP and NodePort service IPSet entries added

### DIFF
--- a/backends/ipvs-as-sink/clusteripsvc.go
+++ b/backends/ipvs-as-sink/clusteripsvc.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvssink
+
+import (
+	"bytes"
+
+	"sigs.k8s.io/kpng/pkg/api/localnetv1"
+)
+
+func (s *Backend) handleClusterIPService(svc *localnetv1.Service, op Operation) {
+	key := svc.Namespace + "/" + svc.Name
+
+	if op == AddService {
+		isNewService := true
+		if _, ok := s.svcs[key]; ok {
+			isNewService = false
+		}
+
+		if isNewService {
+			s.handleNewClusterIPService(key, svc)
+		} else {
+			s.handleUpdatedClusterIPService(key, svc)
+		}
+	}
+
+	if op == DeleteService {
+		s.AddOrDelClusterIPInIPSet(svc, svc.Ports, DeleteService)
+	}
+}
+
+func (s *Backend) handleNewClusterIPService(key string, svc *localnetv1.Service) {
+	s.svcs[key] = svc
+
+	//Cluster service IP is added to kube-ipvs0 interface
+	s.addServiceIPToKubeIPVSIntf(nil, svc)
+
+	//Cluster service IP is stored in LB tree
+	s.storeLBSvc(svc.Ports, svc.IPs.All().All(), key, ClusterIPService)
+
+	//Cluster service IP needs to be programmed in ipset.
+	s.AddOrDelClusterIPInIPSet(svc, svc.Ports, AddService)
+}
+
+func (s *Backend) handleUpdatedClusterIPService(key string, svc *localnetv1.Service) {
+	// update the svc
+	prevSvc := s.svcs[key]
+	s.svcs[key] = svc
+
+	//Updated Cluster service IP is added/removed from kube-ipvs0 interface
+	s.addServiceIPToKubeIPVSIntf(prevSvc, svc)
+
+	// When existing service gets updated with new port/protocol, endpoints
+	// behind it also needs to be updated into tree, so that they are handled in sync().
+	addedPorts, removedPorts := diffInPortMapping(prevSvc, svc)
+
+	if len(addedPorts) > 0 {
+		//Update the service with added ports into LB tree
+		s.storeLBSvc(addedPorts, svc.IPs.All().All(), key, ClusterIPService)
+		var endPointList []string
+
+		for _, epKV := range s.endpoints.GetByPrefix([]byte(key + "/")) {
+			epIP := epKV.Value.(string)
+			endPointList = append(endPointList, epIP)
+			svcIP := getServiceIP(epIP, svc)
+
+			for _, port := range addedPorts {
+				lbKey := key + "/" + svcIP + "/" + epPortSuffix(port)
+				ipvslb := s.lbs.GetByPrefix([]byte(lbKey))
+
+				s.dests.Set([]byte(lbKey+"/"+epIP), 0, ipvsSvcDst{
+					Svc: ipvslb[0].Value.(ipvsLB).ToService(),
+					Dst: ipvsDestination(epIP, port, s.weight),
+				})
+			}
+		}
+
+		//Cluster service IP needs to be programmed in ipset with added ports.
+		s.AddOrDelClusterIPInIPSet(svc, addedPorts, AddService)
+
+		s.AddOrDelEndPointInIPSet(endPointList, addedPorts, AddEndPoint)
+	}
+
+	// When existing service gets updated with deletion of port/protocol,
+	// endpoint behind it needs to be removed from tree.
+	if len(removedPorts) > 0 {
+		s.deleteLBSvc(removedPorts, svc.IPs.All().All(), key)
+		var endPointList []string
+
+		for _, epKV := range s.endpoints.GetByPrefix([]byte(key + "/")) {
+			epIP := epKV.Value.(string)
+			endPointList = append(endPointList, epIP)
+			svcIP := getServiceIP(epIP, svc)
+
+			for _, port := range removedPorts {
+				lbKey := key + "/" + svcIP + "/" + epPortSuffix(port)
+				s.dests.Delete([]byte(lbKey + "/" + epIP))
+			}
+		}
+
+		s.AddOrDelClusterIPInIPSet(svc, removedPorts, DeleteService)
+
+		s.AddOrDelEndPointInIPSet(endPointList, removedPorts, DeleteEndPoint)
+	}
+}
+
+func (s *Backend) SetEndPointForClusterIPSvc(svcKey, key string, endpoint *localnetv1.Endpoint) {
+	prefix := svcKey + "/" + key + "/"
+	service := s.svcs[svcKey]
+	portList := service.Ports
+
+	for _, endPointIP := range endpoint.IPs.All() {
+		s.endpoints.Set([]byte(prefix+endPointIP), 0, endPointIP)
+		svcIP := getServiceIP(endPointIP, service)
+
+		// add a destination for every LB of this service
+		for _, lbKV := range s.lbs.GetByPrefix([]byte(svcKey + "/" + svcIP)) {
+			lb := lbKV.Value.(ipvsLB)
+			destination := ipvsSvcDst{
+				Svc:             lb.ToService(),
+				Dst:             ipvsDestination(endPointIP, lb.Port, s.weight),
+				isLocalEndPoint: endpoint.Local,
+			}
+			s.dests.Set([]byte(string(lbKV.Key)+"/"+endPointIP), 0, destination)
+		}
+	}
+
+	s.AddOrDelEndPointInIPSet(endpoint.IPs.All(), portList, AddEndPoint)
+}
+
+func (s *Backend) DeleteEndPointForClusterIPSvc(svcKey, key string) {
+	prefix := []byte(svcKey + "/" + key + "/")
+	service := s.svcs[svcKey]
+	portList := service.Ports
+	var endPointList []string
+
+	for _, kv := range s.endpoints.GetByPrefix(prefix) {
+		endPointIP := kv.Value.(string)
+		suffix := []byte("/" + endPointIP)
+
+		for _, destKV := range s.dests.GetByPrefix([]byte(svcKey)) {
+			if bytes.HasSuffix(destKV.Key, suffix) {
+				s.dests.Delete(destKV.Key)
+			}
+		}
+		endPointList = append(endPointList, endPointIP)
+	}
+
+	// remove this endpoint from the endpoints
+	s.endpoints.DeleteByPrefix(prefix)
+
+	s.AddOrDelEndPointInIPSet(endPointList, portList, DeleteEndPoint)
+}

--- a/backends/ipvs-as-sink/common.go
+++ b/backends/ipvs-as-sink/common.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvssink
+
+import (
+	"net"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	netutils "k8s.io/utils/net"
+	utilipset "sigs.k8s.io/kpng/backends/util/ipvs"
+	"sigs.k8s.io/kpng/pkg/api/localnetv1"
+)
+
+func (s *Backend) AddOrDelEndPointInIPSet(endPointList []string, portList []*localnetv1.PortMapping, op Operation) {
+	//if !destination.isLocalEndPoint {
+	//	return
+	//}
+	for _, port := range portList {
+		for _, endPointIP := range endPointList {
+			epIPFamily := getIPFamily(endPointIP)
+			ipSetName := loopBackIPSetMap[epIPFamily]
+			entry := getEndPointEntry(endPointIP, port)
+			if valid := s.ipsetList[ipSetName].validateEntry(entry); !valid {
+				klog.Errorf("error adding entry to ipset. entry:%s, ipset:%s", entry.String(), s.ipsetList[ipSetName].Name)
+				return
+			}
+			if op == AddEndPoint {
+				s.ipsetList[ipSetName].newEntries.Insert(entry.String())
+			}
+			if op == DeleteEndPoint {
+				s.ipsetList[ipSetName].deleteEntries.Insert(entry.String())
+			}
+		}
+	}
+}
+
+func getIPFamily(ipAddr string) v1.IPFamily {
+	var ipAddrFamily v1.IPFamily
+	if netutils.IsIPv4String(ipAddr) {
+		ipAddrFamily = v1.IPv4Protocol
+	}
+
+	if netutils.IsIPv6String(ipAddr) {
+		ipAddrFamily = v1.IPv6Protocol
+	}
+	return ipAddrFamily
+}
+
+func getEndPointEntry(endPointIP string, port *localnetv1.PortMapping) *utilipset.Entry {
+	return &utilipset.Entry{
+		IP:       endPointIP,
+		Port:     int(port.TargetPort),
+		Protocol: strings.ToLower(port.Protocol.String()),
+		IP2:      endPointIP,
+		SetType:  utilipset.HashIPPortIP,
+	}
+}
+
+func (s *Backend) AddOrDelClusterIPInIPSet(svc *localnetv1.Service, portList []*localnetv1.PortMapping, op Operation) {
+	svcIPFamily := getServiceIPFamily(svc)
+
+	for _, port := range portList {
+		for _, ipFamily := range svcIPFamily {
+			var clusterIP string
+			if ipFamily == v1.IPv4Protocol {
+				clusterIP = svc.IPs.ClusterIPs.V4[0]
+			}
+			if ipFamily == v1.IPv6Protocol {
+				clusterIP = svc.IPs.ClusterIPs.V6[0]
+			}
+			ipSetName := clusterIPSetMap[ipFamily]
+			// Capture the clusterIP.
+			entry := getIPSetEntry(clusterIP, port)
+			// add service Cluster IP:Port to kubeServiceAccess ip set for the purpose of solving hairpin.
+			if valid := s.ipsetList[ipSetName].validateEntry(entry); !valid {
+				klog.Errorf("error adding entry :%s, to ipset:%s", entry.String(), s.ipsetList[ipSetName].Name)
+				return
+			}
+			if op == AddService {
+				s.ipsetList[ipSetName].newEntries.Insert(entry.String())
+			}
+			if op == DeleteService {
+				s.ipsetList[ipSetName].deleteEntries.Insert(entry.String())
+			}
+		}
+	}
+}
+
+func getServiceIPFamily(svc *localnetv1.Service) []v1.IPFamily {
+	var svcIPFamily []v1.IPFamily
+	if len(svc.IPs.ClusterIPs.V4) > 0 && len(svc.IPs.ClusterIPs.V6) == 0 {
+		svcIPFamily = append(svcIPFamily, v1.IPv4Protocol)
+	}
+
+	if len(svc.IPs.ClusterIPs.V6) > 0 && len(svc.IPs.ClusterIPs.V4) == 0 {
+		svcIPFamily = append(svcIPFamily, v1.IPv6Protocol)
+	}
+
+	if len(svc.IPs.ClusterIPs.V4) > 0 && len(svc.IPs.ClusterIPs.V6) > 0 {
+		svcIPFamily = append(svcIPFamily, v1.IPv4Protocol, v1.IPv6Protocol)
+	}
+	return svcIPFamily
+}
+
+func getIPSetEntry(svcIP string, port *localnetv1.PortMapping) *utilipset.Entry {
+	return &utilipset.Entry{
+		IP:       svcIP,
+		Port:     int(port.Port),
+		Protocol: strings.ToLower(port.Protocol.String()),
+		SetType:  utilipset.HashIPPort,
+	}
+}
+
+func getServiceIP(endPointIP string, svc *localnetv1.Service) string {
+	var svcIP string
+	if netutils.IsIPv4String(endPointIP) {
+		svcIP = svc.IPs.ClusterIPs.V4[0]
+	}
+	if netutils.IsIPv6String(endPointIP) {
+		svcIP = svc.IPs.ClusterIPs.V6[0]
+	}
+	return svcIP
+}
+
+func (s *Backend) addServiceIPToKubeIPVSIntf(prevSvc, curr *localnetv1.Service) {
+	// sync dummy IPs
+	var prevIPs *localnetv1.IPSet
+	if prevSvc == nil {
+		prevIPs = localnetv1.NewIPSet()
+	} else {
+		prevIPs = prevSvc.IPs.All()
+	}
+
+	currentIPs := curr.IPs.All()
+
+	added, removed := prevIPs.Diff(currentIPs)
+
+	for _, ip := range asDummyIPs(added) {
+		if _, ok := s.dummyIPsRefCounts[ip]; !ok {
+			// IP is not referenced so we must add it
+			klog.V(2).Info("adding dummy IP ", ip)
+
+			_, ipNet, err := net.ParseCIDR(ip)
+			if err != nil {
+				klog.Fatalf("failed to parse ip/net %q: %v", ip, err)
+			}
+
+			if err = netlink.AddrAdd(s.dummy, &netlink.Addr{IPNet: ipNet}); err != nil {
+				klog.Error("failed to add dummy IP ", ip, ": ", err)
+			}
+		}
+
+		s.dummyIPsRefCounts[ip]++
+	}
+
+	for _, ip := range asDummyIPs(removed) {
+		s.dummyIPsRefCounts[ip]--
+	}
+}
+
+func (s *Backend) storeLBSvc(portList []*localnetv1.PortMapping, addrList []string, key, svcType string) {
+	for _, ip := range addrList {
+		prefix := key + "/" + ip + "/"
+		for _, port := range portList {
+			lbKey := prefix + epPortSuffix(port)
+			s.lbs.Set([]byte(lbKey), 0, ipvsLB{IP: ip, ServiceKey: key, Port: port, SchedulingMethod: s.schedulingMethod, ServiceType: svcType})
+		}
+	}
+}
+
+func (s *Backend) deleteLBSvc(portList []*localnetv1.PortMapping, addrList []string, key string) {
+	for _, ip := range addrList {
+		prefix := key + "/" + ip + "/"
+		for _, port := range portList {
+			lbKey := prefix + epPortSuffix(port)
+			s.lbs.Delete([]byte(lbKey))
+		}
+	}
+}

--- a/backends/ipvs-as-sink/flags.go
+++ b/backends/ipvs-as-sink/flags.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipvssink
 
 import (

--- a/backends/ipvs-as-sink/ipset.go
+++ b/backends/ipvs-as-sink/ipset.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvssink
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	utilipset "sigs.k8s.io/kpng/backends/util/ipvs"
+
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	kubeLoopBackIPSetComment = "Kubernetes endpoints dst ip:port, source ip for solving hairpin purpose"
+	kubeLoopBackIPv4Set      = "KUBE-LOOP-BACK"
+	kubeLoopBackIPv6Set      = "KUBE-6-LOOP-BACK"
+
+	kubeClusterIPSetComment = "Kubernetes service cluster ip + port for masquerade purpose"
+	kubeClusterIPv4Set      = "KUBE-CLUSTER-IP"
+	kubeClusterIPv6Set      = "KUBE-6-CLUSTER-IP"
+
+	kubeExternalIPSetComment = "Kubernetes service external ip + port for masquerade and filter purpose"
+	kubeExternalIPv4Set      = "KUBE-EXTERNAL-IP"
+	kubeExternalIPv6Set      = "KUBE-6-EXTERNAL-IP"
+
+	kubeExternalIPLocalSetComment = "Kubernetes service external ip + port with externalTrafficPolicy=local"
+	kubeExternalIPv4LocalSet      = "KUBE-EXTERNAL-IP-LOCAL"
+	kubeExternalIPv6LocalSet      = "KUBE-6-EXTERNAL-IP-LOCAL"
+
+	kubeLoadBalancerSetComment = "Kubernetes service lb portal"
+	kubeLoadBalancerIPv4Set    = "KUBE-LOAD-BALANCER"
+	kubeLoadBalancerIPv6Set    = "KUBE-6-LOAD-BALANCER"
+
+	kubeLoadBalancerLocalSetComment = "Kubernetes service load balancer ip + port with externalTrafficPolicy=local"
+	kubeLoadBalancerLocalIPv4Set    = "KUBE-LOAD-BALANCER-LOCAL"
+	kubeLoadBalancerLocalIPv6Set    = "KUBE-6-LOAD-BALANCER-LOCAL"
+
+	kubeLoadbalancerFWSetComment = "Kubernetes service load balancer ip + port for load balancer with sourceRange"
+	kubeLoadbalancerFWIPv4Set    = "KUBE-LOAD-BALANCER-FW"
+	kubeLoadbalancerFWIPv6Set    = "KUBE-6-LOAD-BALANCER-FW"
+
+	kubeLoadBalancerSourceIPSetComment = "Kubernetes service load balancer ip + port + source IP for packet filter purpose"
+	kubeLoadBalancerSourceIPv4Set      = "KUBE-LOAD-BALANCER-SOURCE-IP"
+	kubeLoadBalancerSourceIPv6Set      = "KUBE-6-LOAD-BALANCER-SOURCE-IP"
+
+	kubeLoadBalancerSourceCIDRSetComment = "Kubernetes service load balancer ip + port + source cidr for packet filter purpose"
+	kubeLoadBalancerSourceCIDRIPv4Set    = "KUBE-LOAD-BALANCER-SOURCE-CIDR"
+	kubeLoadBalancerSourceCIDRIPv6Set    = "KUBE-6-LOAD-BALANCER-SOURCE-CIDR"
+
+	kubeNodePortSetTCPComment = "Kubernetes nodeport TCP port for masquerade purpose"
+	kubeNodePortIPv4SetTCP    = "KUBE-NODE-PORT-TCP"
+	kubeNodePortIPv6SetTCP    = "KUBE-6-NODE-PORT-TCP"
+
+	kubeNodePortLocalSetTCPComment = "Kubernetes nodeport TCP port with externalTrafficPolicy=local"
+	kubeNodePortLocalIPv4SetTCP    = "KUBE-NODE-PORT-LOCAL-TCP"
+	kubeNodePortLocalIPv6SetTCP    = "KUBE-6-NODE-PORT-LOCAL-TCP"
+
+	kubeNodePortSetUDPComment = "Kubernetes nodeport UDP port for masquerade purpose"
+	kubeNodePortIPv4SetUDP    = "KUBE-NODE-PORT-UDP"
+	kubeNodePortIPv6SetUDP    = "KUBE-6-NODE-PORT-UDP"
+
+	kubeNodePortLocalSetUDPComment = "Kubernetes nodeport UDP port with externalTrafficPolicy=local"
+	kubeNodePortLocalIPv4SetUDP    = "KUBE-NODE-PORT-LOCAL-UDP"
+	kubeNodePortLocalIPv6SetUDP    = "KUBE-6-NODE-PORT-LOCAL-UDP"
+
+	kubeNodePortSetSCTPComment = "Kubernetes nodeport SCTP port for masquerade purpose with type 'hash ip:port'"
+	kubeNodePortIPv4SetSCTP    = "KUBE-NODE-PORT-SCTP-HASH"
+	kubeNodePortIPv6SetSCTP    = "KUBE-6-NODE-PORT-SCTP-HASH"
+
+	kubeNodePortLocalSetSCTPComment = "Kubernetes nodeport SCTP port with externalTrafficPolicy=local with type 'hash ip:port'"
+	kubeNodePortLocalIPv4SetSCTP    = "KUBE-NODE-PORT-LOCAL-SCTP-HASH"
+	kubeNodePortLocalIPv6SetSCTP    = "KUBE-6-NODE-PORT-LOCAL-SCTP-HASH"
+
+	kubeHealthCheckNodePortSetComment = "Kubernetes health check node port"
+	kubeHealthCheckNodePortIPv4Set    = "KUBE-HEALTH-CHECK-NODE-PORT"
+	kubeHealthCheckNodePortIPv6Set    = "KUBE-6-HEALTH-CHECK-NODE-PORT"
+)
+
+// ipsetInfo is all ipset we needed in ipvs proxier
+var ipsetInfo = []struct {
+	name    string
+	setType utilipset.Type
+	comment string
+}{
+	{kubeLoopBackIPv4Set, utilipset.HashIPPortIP, kubeLoopBackIPSetComment},
+	{kubeClusterIPv4Set, utilipset.HashIPPort, kubeClusterIPSetComment},
+	{kubeExternalIPv4Set, utilipset.HashIPPort, kubeExternalIPSetComment},
+	{kubeExternalIPv4LocalSet, utilipset.HashIPPort, kubeExternalIPLocalSetComment},
+	{kubeLoadBalancerIPv4Set, utilipset.HashIPPort, kubeLoadBalancerSetComment},
+	{kubeLoadbalancerFWIPv4Set, utilipset.HashIPPort, kubeLoadbalancerFWSetComment},
+	{kubeLoadBalancerLocalIPv4Set, utilipset.HashIPPort, kubeLoadBalancerLocalSetComment},
+	{kubeLoadBalancerSourceIPv4Set, utilipset.HashIPPortIP, kubeLoadBalancerSourceIPSetComment},
+	{kubeLoadBalancerSourceCIDRIPv4Set, utilipset.HashIPPortNet, kubeLoadBalancerSourceCIDRSetComment},
+	{kubeNodePortIPv4SetTCP, utilipset.BitmapPort, kubeNodePortSetTCPComment},
+	{kubeNodePortLocalIPv4SetTCP, utilipset.BitmapPort, kubeNodePortLocalSetTCPComment},
+	{kubeNodePortIPv4SetUDP, utilipset.BitmapPort, kubeNodePortSetUDPComment},
+	{kubeNodePortLocalIPv4SetUDP, utilipset.BitmapPort, kubeNodePortLocalSetUDPComment},
+	{kubeNodePortIPv4SetSCTP, utilipset.HashIPPort, kubeNodePortSetSCTPComment},
+	{kubeNodePortLocalIPv4SetSCTP, utilipset.HashIPPort, kubeNodePortLocalSetSCTPComment},
+	{kubeHealthCheckNodePortIPv4Set, utilipset.BitmapPort, kubeHealthCheckNodePortSetComment},
+}
+
+// IPSetVersioner can query the current ipset version.
+type IPSetVersioner interface {
+	// returns "X.Y"
+	GetVersion() (string, error)
+}
+
+type IPSet struct {
+	utilipset.IPSet
+	// activeEntries is the current active entries of the ipset.
+	newEntries sets.String
+	// activeEntries is the current active entries of the ipset.
+	deleteEntries sets.String
+	// handle is the util ipset interface handle.
+	handle utilipset.Interface
+}
+
+// NewIPSet initialize a new IPSet struct
+func newIPv4Set(handle utilipset.Interface, name string, setType utilipset.Type, comment string) *IPSet {
+	hashFamily := utilipset.ProtocolFamilyIPV4
+	set := &IPSet{
+		IPSet: utilipset.IPSet{
+			Name:       name,
+			SetType:    setType,
+			HashFamily: hashFamily,
+			Comment:    comment,
+		},
+		newEntries:    sets.NewString(),
+		deleteEntries: sets.NewString(),
+		handle:        handle,
+	}
+	return set
+}
+
+// NewIPSet initialize a new IPSet struct
+func newIPv6Set(handle utilipset.Interface, name string, setType utilipset.Type, comment string) *IPSet {
+	hashFamily := utilipset.ProtocolFamilyIPV6
+	// In dual-stack both ipv4 and ipv6 ipset's can co-exist. To
+	// ensure unique names the prefix for ipv6 is changed from
+	// "KUBE-" to "KUBE-6-". The "KUBE-" prefix is kept for
+	// backward compatibility. The maximum name length of an ipset
+	// is 31 characters which must be taken into account.  The
+	// ipv4 names are not altered to minimize the risk for
+	// problems on upgrades.
+	if strings.HasPrefix(name, "KUBE-") {
+		name = strings.Replace(name, "KUBE-", "KUBE-6-", 1)
+		if len(name) > 31 {
+			klog.Warningf("ipset name truncated; [%s] -> [%s]", name, name[:31])
+			name = name[:31]
+		}
+	}
+	set := &IPSet{
+		IPSet: utilipset.IPSet{
+			Name:       name,
+			SetType:    setType,
+			HashFamily: hashFamily,
+			Comment:    comment,
+		},
+		newEntries:    sets.NewString(),
+		deleteEntries: sets.NewString(),
+		handle:        handle,
+	}
+	return set
+}
+
+func (set *IPSet) validateEntry(entry *utilipset.Entry) bool {
+	return entry.Validate(&set.IPSet)
+}
+
+func (set *IPSet) getComment() string {
+	return fmt.Sprintf("\"%s\"", set.Comment)
+}
+
+func (set *IPSet) resetEntries() {
+	set.newEntries = sets.NewString()
+	set.deleteEntries = sets.NewString()
+}
+
+func (set *IPSet) syncIPSetEntries() {
+	// Create entries
+	for _, entry := range set.newEntries.List() {
+		if err := set.handle.AddEntry(entry, &set.IPSet, true); err != nil {
+			klog.Errorf("Failed to add entry %v into ip set: %s, error: %v", entry, set.Name, err)
+		} else {
+			klog.V(3).Infof("Successfully add entry: %v into ip set: %s", entry, set.Name)
+		}
+	}
+
+	// Delete entries
+	for _, entry := range set.deleteEntries.List() {
+		if err := set.handle.DelEntry(entry, set.Name); err != nil {
+			klog.Errorf("Failed to delete entry: %v from ip set: %s, error: %v", entry, set.Name, err)
+		} else {
+			klog.V(3).Infof("Successfully deleted entry: %v to ip set: %s", entry, set.Name)
+		}
+	}
+
+}
+
+func ensureIPSet(set *IPSet) error {
+	if err := set.handle.CreateSet(&set.IPSet, true); err != nil {
+		klog.Errorf("Failed to ensure ip set %v exist, error: %v", set, err)
+		return err
+	}
+	return nil
+}

--- a/backends/ipvs-as-sink/lb.go
+++ b/backends/ipvs-as-sink/lb.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ipvssink
 
 import (
@@ -57,6 +73,7 @@ func ipvsDestination(targetIP string, port *localnetv1.PortMapping, epWeight int
 }
 
 type ipvsSvcDst struct {
-	Svc ipvs.Service
-	Dst ipvs.Destination
+	Svc             ipvs.Service
+	Dst             ipvs.Destination
+	isLocalEndPoint bool
 }

--- a/backends/ipvs-as-sink/nodeportsvc.go
+++ b/backends/ipvs-as-sink/nodeportsvc.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvssink
+
+import (
+	"bytes"
+	"strings"
+
+	"k8s.io/klog/v2"
+	utilipset "sigs.k8s.io/kpng/backends/util/ipvs"
+	"sigs.k8s.io/kpng/pkg/api/localnetv1"
+)
+
+func (s *Backend) handleNodePortService(svc *localnetv1.Service, op Operation) {
+	svckey := svc.Namespace + "/" + svc.Name
+
+	if op == AddService {
+		isNewService := true
+		if _, ok := s.svcs[svckey]; ok {
+			isNewService = false
+		}
+
+		if isNewService {
+			s.handleNewNodePortService(svckey, svc)
+		} else {
+			s.handleUpdatedNodePortService(svckey, svc)
+		}
+	}
+
+	if op == DeleteService {
+		portList := svc.Ports
+
+		s.AddOrDelNodePortInIPSet(svc, portList, DeleteService)
+
+		s.AddOrDelClusterIPInIPSet(svc, svc.Ports, DeleteService)
+	}
+}
+
+func (s *Backend) handleNewNodePortService(key string, svc *localnetv1.Service) {
+	s.svcs[key] = svc
+
+	s.addServiceIPToKubeIPVSIntf(nil, svc)
+
+	//Node Addresses need to be added as NodePortService
+	//so that in sync(), nodePort is attached to nodeIPs.
+	s.storeLBSvc(svc.Ports, s.nodeAddresses, key, NodePortService)
+
+	//NodePort svc clusterIPs need to be added as ClusterIPService
+	//so that in sync(), port is attached to clusterIP.
+	s.storeLBSvc(svc.Ports, svc.IPs.All().All(), key, ClusterIPService)
+
+	portList := svc.Ports
+	s.AddOrDelNodePortInIPSet(svc, portList, AddService)
+
+	s.AddOrDelClusterIPInIPSet(svc, svc.Ports, AddService)
+}
+
+func (s *Backend) handleUpdatedNodePortService(svckey string, svc *localnetv1.Service) {
+	// update the svc
+	prevSvc := s.svcs[svckey]
+	s.svcs[svckey] = svc
+
+	s.addServiceIPToKubeIPVSIntf(prevSvc, svc)
+
+	addedPorts, removedPorts := diffInPortMapping(prevSvc, svc)
+
+	if len(addedPorts) > 0 {
+		//Node Addresses need to be added as NodePortService
+		//so that in sync(), nodePort is attached to nodeIPs.
+		s.storeLBSvc(addedPorts, s.nodeAddresses, svckey, NodePortService)
+
+		//NodePort service clusterIPs need to be added as ClusterIPService
+		//so that in sync(), port is attached to clusterIP.
+		s.storeLBSvc(addedPorts, svc.IPs.All().All(), svckey, ClusterIPService)
+
+		s.AddOrDelNodePortInIPSet(svc, addedPorts, AddService)
+
+		for _, epKV := range s.endpoints.GetByPrefix([]byte(svckey + "/")) {
+			endPointIP := epKV.Value.(string)
+
+			for _, lbKV := range s.lbs.GetByPrefix([]byte(svckey + "/")) {
+				lb := lbKV.Value.(ipvsLB)
+
+				if getIPFamily(endPointIP) == getIPFamily(lb.IP) {
+					for _, port := range addedPorts {
+						lbKey := svckey + "/" + lb.IP + "/" + epPortSuffix(port)
+						s.dests.Set([]byte(lbKey+"/"+endPointIP), 0, ipvsSvcDst{
+							Svc: lb.ToService(),
+							Dst: ipvsDestination(endPointIP, port, s.weight),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	if len(removedPorts) > 0 {
+		for _, epKV := range s.endpoints.GetByPrefix([]byte(svckey + "/")) {
+			endPointIP := epKV.Value.(string)
+
+			for _, lbKV := range s.lbs.GetByPrefix([]byte(svckey + "/")) {
+				lb := lbKV.Value.(ipvsLB)
+				if getIPFamily(endPointIP) == getIPFamily(lb.IP) {
+					for _, port := range removedPorts {
+						lbKey := svckey + "/" + lb.IP + "/" + epPortSuffix(port)
+						s.dests.Delete([]byte(lbKey + "/" + endPointIP))
+					}
+				}
+			}
+		}
+
+		s.deleteLBSvc(removedPorts, s.nodeAddresses, svckey)
+
+		s.deleteLBSvc(removedPorts, svc.IPs.All().All(), svckey)
+
+		s.AddOrDelNodePortInIPSet(svc, removedPorts, DeleteService)
+	}
+}
+
+func (s *Backend) AddOrDelNodePortInIPSet(svc *localnetv1.Service, portList []*localnetv1.PortMapping, op Operation) {
+	svcIPFamily := getServiceIPFamily(svc)
+
+	for _, port := range portList {
+		var entries []*utilipset.Entry
+		for _, ipFamily := range svcIPFamily {
+			protocol := strings.ToLower(port.Protocol.String())
+			ipsetName := protocolIPSetMap[protocol][ipFamily]
+			nodePortSet := s.ipsetList[ipsetName]
+			switch protocol {
+			case utilipset.ProtocolTCP, utilipset.ProtocolUDP:
+				entries = []*utilipset.Entry{getNodePortIPSetEntry(int(port.NodePort), protocol, utilipset.BitmapPort)}
+
+			case utilipset.ProtocolSCTP:
+				// Since hash ip:port is used for SCTP, all the nodeIPs to be used in the SCTP ipset entries.
+				entries = []*utilipset.Entry{}
+				for _, nodeIP := range s.nodeAddresses {
+					entry := getNodePortIPSetEntry(int(port.NodePort), protocol, utilipset.HashIPPort)
+					entry.IP = nodeIP
+					entries = append(entries, entry)
+				}
+			default:
+				// It should never hit
+				klog.ErrorS(nil, "Unsupported protocol type", "protocol", protocol)
+			}
+			if nodePortSet != nil {
+				for _, entry := range entries {
+					if valid := nodePortSet.validateEntry(entry); !valid {
+						klog.ErrorS(nil, "error adding entry to ipset", "entry", entry.String(), "ipset", nodePortSet.Name)
+					}
+					if op == AddService {
+						nodePortSet.newEntries.Insert(entry.String())
+					}
+					if op == DeleteService {
+						nodePortSet.deleteEntries.Insert(entry.String())
+					}
+				}
+			}
+		}
+	}
+}
+
+func getNodePortIPSetEntry(port int, protocol string, ipSetType utilipset.Type) *utilipset.Entry {
+	return &utilipset.Entry{
+		// No need to provide ip info
+		Port:     port,
+		Protocol: protocol,
+		SetType:  ipSetType,
+	}
+}
+
+func (s *Backend) SetEndPointForNodePortSvc(svcKey, key string, endpoint *localnetv1.Endpoint) {
+	prefix := svcKey + "/" + key + "/"
+	service := s.svcs[svcKey]
+	portList := service.Ports
+
+	for _, endPointIP := range endpoint.IPs.All() {
+		s.endpoints.Set([]byte(prefix+endPointIP), 0, endPointIP)
+
+		// add a destination for every LB of this service
+		for _, lbKV := range s.lbs.GetByPrefix([]byte(svcKey + "/")) {
+			lb := lbKV.Value.(ipvsLB)
+
+			if getIPFamily(endPointIP) == getIPFamily(lb.IP) {
+				destination := ipvsSvcDst{
+					Svc:             lb.ToService(),
+					Dst:             ipvsDestination(endPointIP, lb.Port, s.weight),
+					isLocalEndPoint: endpoint.Local,
+				}
+				s.dests.Set([]byte(string(lbKV.Key)+"/"+endPointIP), 0, destination)
+			}
+		}
+	}
+
+	s.AddOrDelEndPointInIPSet(endpoint.IPs.All(), portList, AddEndPoint)
+}
+
+func (s *Backend) DeleteEndPointForNodePortSvc(svcKey, key string) {
+	prefix := []byte(svcKey + "/" + key + "/")
+	service := s.svcs[svcKey]
+	portList := service.Ports
+	var endPointList []string
+
+	for _, kv := range s.endpoints.GetByPrefix(prefix) {
+		// remove this endpoint from the destinations if the service
+		endPointIP := kv.Value.(string)
+		suffix := []byte("/" + endPointIP)
+
+		for _, destKV := range s.dests.GetByPrefix([]byte(svcKey)) {
+			if bytes.HasSuffix(destKV.Key, suffix) {
+				s.dests.Delete(destKV.Key)
+			}
+		}
+
+		endPointList = append(endPointList, endPointIP)
+	}
+
+	// remove this endpoint from the endpoints
+	s.endpoints.DeleteByPrefix(prefix)
+
+	s.AddOrDelEndPointInIPSet(endPointList, portList, DeleteEndPoint)
+}

--- a/backends/util/ipvs/ipset.go
+++ b/backends/util/ipvs/ipset.go
@@ -1,0 +1,528 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvs
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+	utilexec "k8s.io/utils/exec"
+)
+
+// Interface is an injectable interface for running ipset commands.  Implementations must be goroutine-safe.
+type Interface interface {
+	// FlushSet deletes all entries from a named set.
+	FlushSet(set string) error
+	// DestroySet deletes a named set.
+	DestroySet(set string) error
+	// DestroyAllSets deletes all sets.
+	DestroyAllSets() error
+	// CreateSet creates a new set.  It will ignore error when the set already exists if ignoreExistErr=true.
+	CreateSet(set *IPSet, ignoreExistErr bool) error
+	// AddEntry adds a new entry to the named set.  It will ignore error when the entry already exists if ignoreExistErr=true.
+	AddEntry(entry string, set *IPSet, ignoreExistErr bool) error
+	// DelEntry deletes one entry from the named set
+	DelEntry(entry string, set string) error
+	// Test test if an entry exists in the named set
+	TestEntry(entry string, set string) (bool, error)
+	// ListEntries lists all the entries from a named set
+	ListEntries(set string) ([]string, error)
+	// ListSets list all set names from kernel
+	ListSets() ([]string, error)
+	// GetVersion returns the "X.Y" version string for ipset.
+	GetVersion() (string, error)
+}
+
+// IPSetCmd represents the ipset util. We use ipset command for ipset execute.
+const IPSetCmd = "ipset"
+
+// EntryMemberPattern is the regular expression pattern of ipset member list.
+// The raw output of ipset command `ipset list {set}` is similar to,
+//Name: foobar
+//Type: hash:ip,port
+//Revision: 2
+//Header: family inet hashsize 1024 maxelem 65536
+//Size in memory: 16592
+//References: 0
+//Members:
+//192.168.1.2,tcp:8080
+//192.168.1.1,udp:53
+var EntryMemberPattern = "(?m)^(.*\n)*Members:\n"
+
+// VersionPattern is the regular expression pattern of ipset version string.
+// ipset version output is similar to "v6.10".
+var VersionPattern = "v[0-9]+\\.[0-9]+"
+
+// IPSet implements an Interface to a set.
+type IPSet struct {
+	// Name is the set name.
+	Name string
+	// SetType specifies the ipset type.
+	SetType Type
+	// HashFamily specifies the protocol family of the IP addresses to be stored in the set.
+	// The default is inet, i.e IPv4.  If users want to use IPv6, they should specify inet6.
+	HashFamily string
+	// HashSize specifies the hash table size of ipset.
+	HashSize int
+	// MaxElem specifies the max element number of ipset.
+	MaxElem int
+	// PortRange specifies the port range of bitmap:port type ipset.
+	PortRange string
+	// comment message for ipset
+	Comment string
+}
+
+// Validate checks if a given ipset is valid or not.
+func (set *IPSet) Validate() bool {
+	// Check if protocol is valid for `HashIPPort`, `HashIPPortIP` and `HashIPPortNet` type set.
+	if set.SetType == HashIPPort || set.SetType == HashIPPortIP || set.SetType == HashIPPortNet {
+		if valid := validateHashFamily(set.HashFamily); !valid {
+			return false
+		}
+	}
+	// check set type
+	if valid := validateIPSetType(set.SetType); !valid {
+		return false
+	}
+	// check port range for bitmap type set
+	if set.SetType == BitmapPort {
+		if valid := validatePortRange(set.PortRange); !valid {
+			return false
+		}
+	}
+	// check hash size value of ipset
+	if set.HashSize <= 0 {
+		klog.Errorf("Invalid hashsize value %d, should be >0", set.HashSize)
+		return false
+	}
+	// check max elem value of ipset
+	if set.MaxElem <= 0 {
+		klog.Errorf("Invalid maxelem value %d, should be >0", set.MaxElem)
+		return false
+	}
+
+	return true
+}
+
+//setIPSetDefaults sets some IPSet fields if not present to their default values.
+func (set *IPSet) setIPSetDefaults() {
+	// Setting default values if not present
+	if set.HashSize == 0 {
+		set.HashSize = 1024
+	}
+	if set.MaxElem == 0 {
+		set.MaxElem = 65536
+	}
+	// Default protocol is IPv4
+	if set.HashFamily == "" {
+		set.HashFamily = ProtocolFamilyIPV4
+	}
+	// Default ipset type is "hash:ip,port"
+	if len(set.SetType) == 0 {
+		set.SetType = HashIPPort
+	}
+	if len(set.PortRange) == 0 {
+		set.PortRange = DefaultPortRange
+	}
+}
+
+// Entry represents a ipset entry.
+type Entry struct {
+	// IP is the entry's IP.  The IP address protocol corresponds to the HashFamily of IPSet.
+	// All entries' IP addresses in the same ip set has same the protocol, IPv4 or IPv6.
+	IP string
+	// Port is the entry's Port.
+	Port int
+	// Protocol is the entry's Protocol.  The protocols of entries in the same ip set are all
+	// the same.  The accepted protocols are TCP, UDP and SCTP.
+	Protocol string
+	// Net is the entry's IP network address.  Network address with zero prefix size can NOT
+	// be stored.
+	Net string
+	// IP2 is the entry's second IP.  IP2 may not be empty for `hash:ip,port,ip` type ip set.
+	IP2 string
+	// SetType is the type of ipset where the entry exists.
+	SetType Type
+}
+
+// Validate checks if a given ipset entry is valid or not.  The set parameter is the ipset that entry belongs to.
+func (e *Entry) Validate(set *IPSet) bool {
+	if e.Port < 0 {
+		klog.Errorf("Entry %v port number %d should be >=0 for ipset %v", e, e.Port, set)
+		return false
+	}
+	switch e.SetType {
+	case HashIPPort:
+		//check if IP and Protocol of Entry is valid.
+		if valid := e.checkIPandProtocol(set); !valid {
+			return false
+		}
+	case HashIPPortIP:
+		//check if IP and Protocol of Entry is valid.
+		if valid := e.checkIPandProtocol(set); !valid {
+			return false
+		}
+
+		// IP2 can not be empty for `hash:ip,port,ip` type ip set
+		if net.ParseIP(e.IP2) == nil {
+			klog.Errorf("Error parsing entry %v second ip address %v for ipset %v", e, e.IP2, set)
+			return false
+		}
+	case HashIPPortNet:
+		//check if IP and Protocol of Entry is valid.
+		if valid := e.checkIPandProtocol(set); !valid {
+			return false
+		}
+
+		// Net can not be empty for `hash:ip,port,net` type ip set
+		if _, ipNet, err := net.ParseCIDR(e.Net); ipNet == nil {
+			klog.Errorf("Error parsing entry %v ip net %v for ipset %v, error: %v", e, e.Net, set, err)
+			return false
+		}
+	case BitmapPort:
+		// check if port number satisfies its ipset's requirement of port range
+		if set == nil {
+			klog.Errorf("Unable to reference ip set where the entry %v exists", e)
+			return false
+		}
+		begin, end, err := parsePortRange(set.PortRange)
+		if err != nil {
+			klog.Errorf("Failed to parse set %v port range %s for ipset %v, error: %v", set, set.PortRange, set, err)
+			return false
+		}
+		if e.Port < begin || e.Port > end {
+			klog.Errorf("Entry %v port number %d is not in the port range %s of its ipset %v", e, e.Port, set.PortRange, set)
+			return false
+		}
+	}
+
+	return true
+}
+
+// String returns the string format for ipset entry.
+func (e *Entry) String() string {
+	switch e.SetType {
+	case HashIPPort:
+		// Entry{192.168.1.1, udp, 53} -> 192.168.1.1,udp:53
+		// Entry{192.168.1.2, tcp, 8080} -> 192.168.1.2,tcp:8080
+		return fmt.Sprintf("%s,%s:%s", e.IP, e.Protocol, strconv.Itoa(e.Port))
+	case HashIPPortIP:
+		// Entry{192.168.1.1, udp, 53, 10.0.0.1} -> 192.168.1.1,udp:53,10.0.0.1
+		// Entry{192.168.1.2, tcp, 8080, 192.168.1.2} -> 192.168.1.2,tcp:8080,192.168.1.2
+		return fmt.Sprintf("%s,%s:%s,%s", e.IP, e.Protocol, strconv.Itoa(e.Port), e.IP2)
+	case HashIPPortNet:
+		// Entry{192.168.1.2, udp, 80, 10.0.1.0/24} -> 192.168.1.2,udp:80,10.0.1.0/24
+		// Entry{192.168.2,25, tcp, 8080, 10.1.0.0/16} -> 192.168.2,25,tcp:8080,10.1.0.0/16
+		return fmt.Sprintf("%s,%s:%s,%s", e.IP, e.Protocol, strconv.Itoa(e.Port), e.Net)
+	case BitmapPort:
+		// Entry{53} -> 53
+		// Entry{8080} -> 8080
+		return strconv.Itoa(e.Port)
+	}
+	return ""
+}
+
+// checkIPandProtocol checks if IP and Protocol of Entry is valid.
+func (e *Entry) checkIPandProtocol(set *IPSet) bool {
+	// set default protocol to tcp if empty
+	if len(e.Protocol) == 0 {
+		e.Protocol = ProtocolTCP
+	} else if !validateProtocol(e.Protocol) {
+		return false
+	}
+
+	if net.ParseIP(e.IP) == nil {
+		klog.Errorf("Error parsing entry %v ip address %v for ipset %v", e, e.IP, set)
+		return false
+	}
+
+	return true
+}
+
+type runner struct {
+	exec utilexec.Interface
+}
+
+// New returns a new Interface which will exec ipset.
+func New(exec utilexec.Interface) Interface {
+	return &runner{
+		exec: exec,
+	}
+}
+
+// CreateSet creates a new set, it will ignore error when the set already exists if ignoreExistErr=true.
+func (runner *runner) CreateSet(set *IPSet, ignoreExistErr bool) error {
+	// sets some IPSet fields if not present to their default values.
+	set.setIPSetDefaults()
+
+	// Validate ipset before creating
+	valid := set.Validate()
+	if !valid {
+		return fmt.Errorf("error creating ipset since it's invalid")
+	}
+	return runner.createSet(set, ignoreExistErr)
+}
+
+// If ignoreExistErr is set to true, then the -exist option of ipset will be specified, ipset ignores the error
+// otherwise raised when the same set (setname and create parameters are identical) already exists.
+func (runner *runner) createSet(set *IPSet, ignoreExistErr bool) error {
+	args := []string{"create", set.Name, string(set.SetType)}
+	if set.SetType == HashIPPortIP || set.SetType == HashIPPort || set.SetType == HashIPPortNet {
+		args = append(args,
+			"family", set.HashFamily,
+			"hashsize", strconv.Itoa(set.HashSize),
+			"maxelem", strconv.Itoa(set.MaxElem),
+		)
+	}
+	if set.SetType == BitmapPort {
+		args = append(args, "range", set.PortRange)
+	}
+	if ignoreExistErr {
+		args = append(args, "-exist")
+	}
+	if _, err := runner.exec.Command(IPSetCmd, args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("error creating ipset %s, error: %v", set.Name, err)
+	}
+	return nil
+}
+
+// AddEntry adds a new entry to the named set.
+// If the -exist option is specified, ipset ignores the error otherwise raised when
+// the same set (setname and create parameters are identical) already exists.
+func (runner *runner) AddEntry(entry string, set *IPSet, ignoreExistErr bool) error {
+	args := []string{"add", set.Name, entry}
+	if ignoreExistErr {
+		args = append(args, "-exist")
+	}
+	if _, err := runner.exec.Command(IPSetCmd, args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("error adding entry %s, error: %v", entry, err)
+	}
+	return nil
+}
+
+// DelEntry is used to delete the specified entry from the set.
+func (runner *runner) DelEntry(entry string, set string) error {
+	if _, err := runner.exec.Command(IPSetCmd, "del", set, entry).CombinedOutput(); err != nil {
+		return fmt.Errorf("error deleting entry %s: from set: %s, error: %v", entry, set, err)
+	}
+	return nil
+}
+
+// TestEntry is used to check whether the specified entry is in the set or not.
+func (runner *runner) TestEntry(entry string, set string) (bool, error) {
+	if out, err := runner.exec.Command(IPSetCmd, "test", set, entry).CombinedOutput(); err == nil {
+		reg, e := regexp.Compile("is NOT in set " + set)
+		if e == nil && reg.MatchString(string(out)) {
+			return false, nil
+		} else if e == nil {
+			return true, nil
+		} else {
+			return false, fmt.Errorf("error testing entry: %s, error: %v", entry, e)
+		}
+	} else {
+		return false, fmt.Errorf("error testing entry %s: %v (%s)", entry, err, out)
+	}
+}
+
+// FlushSet deletes all entries from a named set.
+func (runner *runner) FlushSet(set string) error {
+	if _, err := runner.exec.Command(IPSetCmd, "flush", set).CombinedOutput(); err != nil {
+		return fmt.Errorf("error flushing set: %s, error: %v", set, err)
+	}
+	return nil
+}
+
+// DestroySet is used to destroy a named set.
+func (runner *runner) DestroySet(set string) error {
+	if out, err := runner.exec.Command(IPSetCmd, "destroy", set).CombinedOutput(); err != nil {
+		return fmt.Errorf("error destroying set %s, error: %v(%s)", set, err, out)
+	}
+	return nil
+}
+
+// DestroyAllSets is used to destroy all sets.
+func (runner *runner) DestroyAllSets() error {
+	if _, err := runner.exec.Command(IPSetCmd, "destroy").CombinedOutput(); err != nil {
+		return fmt.Errorf("error destroying all sets, error: %v", err)
+	}
+	return nil
+}
+
+// ListSets list all set names from kernel
+func (runner *runner) ListSets() ([]string, error) {
+	out, err := runner.exec.Command(IPSetCmd, "list", "-n").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error listing all sets, error: %v", err)
+	}
+	return strings.Split(string(out), "\n"), nil
+}
+
+// ListEntries lists all the entries from a named set.
+func (runner *runner) ListEntries(set string) ([]string, error) {
+	if len(set) == 0 {
+		return nil, fmt.Errorf("set name can't be nil")
+	}
+	out, err := runner.exec.Command(IPSetCmd, "list", set).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error listing set: %s, error: %v", set, err)
+	}
+	memberMatcher := regexp.MustCompile(EntryMemberPattern)
+	list := memberMatcher.ReplaceAllString(string(out[:]), "")
+	strs := strings.Split(list, "\n")
+	results := make([]string, 0)
+	for i := range strs {
+		if len(strs[i]) > 0 {
+			results = append(results, strs[i])
+		}
+	}
+	return results, nil
+}
+
+// GetVersion returns the version string.
+func (runner *runner) GetVersion() (string, error) {
+	return getIPSetVersionString(runner.exec)
+}
+
+// getIPSetVersionString runs "ipset --version" to get the version string
+// in the form of "X.Y", i.e "6.19"
+func getIPSetVersionString(exec utilexec.Interface) (string, error) {
+	cmd := exec.Command(IPSetCmd, "--version")
+	cmd.SetStdin(bytes.NewReader([]byte{}))
+	bytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	versionMatcher := regexp.MustCompile(VersionPattern)
+	match := versionMatcher.FindStringSubmatch(string(bytes))
+	if match == nil {
+		return "", fmt.Errorf("no ipset version found in string: %s", bytes)
+	}
+	return match[0], nil
+}
+
+// checks if port range is valid. The begin port number is not necessarily less than
+// end port number - ipset util can accept it.  It means both 1-100 and 100-1 are valid.
+func validatePortRange(portRange string) bool {
+	strs := strings.Split(portRange, "-")
+	if len(strs) != 2 {
+		klog.Errorf("port range should be in the format of `a-b`")
+		return false
+	}
+	for i := range strs {
+		num, err := strconv.Atoi(strs[i])
+		if err != nil {
+			klog.Errorf("Failed to parse %s, error: %v", strs[i], err)
+			return false
+		}
+		if num < 0 {
+			klog.Errorf("port number %d should be >=0", num)
+			return false
+		}
+	}
+	return true
+}
+
+// checks if the given ipset type is valid.
+func validateIPSetType(set Type) bool {
+	for _, valid := range ValidIPSetTypes {
+		if set == valid {
+			return true
+		}
+	}
+	klog.Errorf("Currently supported ipset types are: %v, %s is not supported", ValidIPSetTypes, set)
+	return false
+}
+
+// checks if given hash family is supported in ipset
+func validateHashFamily(family string) bool {
+	if family == ProtocolFamilyIPV4 || family == ProtocolFamilyIPV6 {
+		return true
+	}
+	klog.Errorf("Currently supported ip set hash families are: [%s, %s], %s is not supported", ProtocolFamilyIPV4, ProtocolFamilyIPV6, family)
+	return false
+}
+
+// IsNotFoundError returns true if the error indicates "not found".  It parses
+// the error string looking for known values, which is imperfect but works in
+// practice.
+func IsNotFoundError(err error) bool {
+	es := err.Error()
+	if strings.Contains(es, "does not exist") {
+		// set with the same name already exists
+		// xref: https://github.com/Olipro/ipset/blob/master/lib/errcode.c#L32-L33
+		return true
+	}
+	if strings.Contains(es, "element is missing") {
+		// entry is missing from the set
+		// xref: https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1904
+		// https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1925
+		return true
+	}
+	return false
+}
+
+// checks if given protocol is supported in entry
+func validateProtocol(protocol string) bool {
+	if protocol == ProtocolTCP || protocol == ProtocolUDP || protocol == ProtocolSCTP {
+		return true
+	}
+	klog.Errorf("Invalid entry's protocol: %s, supported protocols are [%s, %s, %s]", protocol, ProtocolTCP, ProtocolUDP, ProtocolSCTP)
+	return false
+}
+
+// parsePortRange parse the begin and end port from a raw string(format: a-b).  beginPort <= endPort
+// in the return value.
+func parsePortRange(portRange string) (beginPort int, endPort int, err error) {
+	if len(portRange) == 0 {
+		portRange = DefaultPortRange
+	}
+
+	strs := strings.Split(portRange, "-")
+	if len(strs) != 2 {
+		// port number -1 indicates invalid
+		return -1, -1, fmt.Errorf("port range should be in the format of `a-b`")
+	}
+	for i := range strs {
+		num, err := strconv.Atoi(strs[i])
+		if err != nil {
+			// port number -1 indicates invalid
+			return -1, -1, err
+		}
+		if num < 0 {
+			// port number -1 indicates invalid
+			return -1, -1, fmt.Errorf("port number %d should be >=0", num)
+		}
+		if i == 0 {
+			beginPort = num
+			continue
+		}
+		endPort = num
+		// switch when first port number > second port number
+		if beginPort > endPort {
+			endPort = beginPort
+			beginPort = num
+		}
+	}
+	return beginPort, endPort, nil
+}
+
+var _ = Interface(&runner{})

--- a/backends/util/ipvs/types.go
+++ b/backends/util/ipvs/types.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvs
+
+// Type represents the ipset type
+type Type string
+
+const (
+	// HashIPPort represents the `hash:ip,port` type ipset.  The hash:ip,port is similar to hash:ip but
+	// you can store IP address and protocol-port pairs in it.  TCP, SCTP, UDP, UDPLITE, ICMP and ICMPv6 are supported
+	// with port numbers/ICMP(v6) types and other protocol numbers without port information.
+	HashIPPort Type = "hash:ip,port"
+	// HashIPPortIP represents the `hash:ip,port,ip` type ipset.  The hash:ip,port,ip set type uses a hash to store
+	// IP address, port number and a second IP address triples.  The port number is interpreted together with a
+	// protocol (default TCP) and zero protocol number cannot be used.
+	HashIPPortIP Type = "hash:ip,port,ip"
+	// HashIPPortNet represents the `hash:ip,port,net` type ipset.  The hash:ip,port,net set type uses a hash to store IP address, port number and IP network address triples.  The port
+	// number is interpreted together with a protocol (default TCP) and zero protocol number cannot be used.   Network address
+	// with zero prefix size cannot be stored either.
+	HashIPPortNet Type = "hash:ip,port,net"
+	// BitmapPort represents the `bitmap:port` type ipset.  The bitmap:port set type uses a memory range, where each bit
+	// represents one TCP/UDP port.  A bitmap:port type of set can store up to 65535 ports.
+	BitmapPort Type = "bitmap:port"
+)
+
+// DefaultPortRange defines the default bitmap:port valid port range.
+const DefaultPortRange string = "0-65535"
+
+const (
+	// ProtocolFamilyIPV4 represents IPv4 protocol.
+	ProtocolFamilyIPV4 = "inet"
+	// ProtocolFamilyIPV6 represents IPv6 protocol.
+	ProtocolFamilyIPV6 = "inet6"
+	// ProtocolTCP represents TCP protocol.
+	ProtocolTCP = "tcp"
+	// ProtocolUDP represents UDP protocol.
+	ProtocolUDP = "udp"
+	// ProtocolSCTP represents SCTP protocol.
+	ProtocolSCTP = "sctp"
+)
+
+// ValidIPSetTypes defines the supported ip set type.
+var ValidIPSetTypes = []Type{
+	HashIPPort,
+	HashIPPortIP,
+	BitmapPort,
+	HashIPPortNet,
+}


### PR DESCRIPTION
This PR contains following code changes

a) ClusterIP , NodePort related IPSet are added.

KUBE-LOOP-BACK
KUBE-6-LOOP-BACK
KUBE-CLUSTER-IP
KUBE-6-CLUSTER-IP
KUBE-NODE-PORT-TCP
KUBE-6-NODE-PORT-TCP
KUBE-NODE-PORT-UDP
KUBE-6-NODE-PORT-UDP

Other IPSets will be added in subsequent review

b) Dual stack handling for service and endpoints