### PR TITLE
more generic build.sh

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -36,8 +36,7 @@ function build_package() {
 
 function build_all_backends() {
   cd ./backends
-  for f in $(find . -type f -name 'go.mod' | sed -r 's|/[^/]+$||' |sort |uniq)
-    do build_package $f; done
+  for f in $(find -name go.mod); do build_package $(dirname $f); done
 }
 
 case $package in

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
-# TODO add license
+# Copyright 2021 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 package=$1
 
 # removing output from pushd
-pushd () {
+function pushd () {
   command pushd "$@" > /dev/null
 }
 # removing output from popd
-popd () {
+function popd () {
   command popd "$@" > /dev/null
 }
 
@@ -23,9 +35,9 @@ function build_package() {
 }
 
 function build_all_backends() {
-  build_package backends/iptables
-  build_package backends/ipvs-as-sink
-  build_package backends/nft
+  cd ./backends
+  for f in $(find . -type f -name 'go.mod' | sed -r 's|/[^/]+$||' |sort |uniq)
+    do build_package $f; done
 }
 
 case $package in


### PR DESCRIPTION
I changed the logic in `build.sh` so new backend packages would automatically also be tested and if 'old' backends get removed nothing breaks. On purpose, this only changes the code that is NOT used by GH actions.

I also added the license boilerplate text.