### PR TITLE
[wip] adding antrea to kpng-local-up.sh

### DIFF
--- a/hack/test_sonobuoy.sh
+++ b/hack/test_sonobuoy.sh
@@ -14,13 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function quick_test() {
+function quick_test {
   ./setup_sonobuoy.sh
   ./sonobuoy/sonobuoy run --mode quick --wait
 }
 
 # cd to dir of script
 cd "${0%/*}"
-
 
 quick_test


### PR DESCRIPTION
```
export CNI=antrea
./hack/kpng.local-up.sh
```

I temporarily set antrea as default. This should be set back to calico before merging. But until then, there is more work to do.