### PR TITLE
porting iptable changes from kube-proxy

### DIFF
--- a/backends/iptables/util/iptables_save_restore.go
+++ b/backends/iptables/util/iptables_save_restore.go
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package iptables
+package util
 
 import (
 	"bytes"
 	"fmt"
-	"sigs.k8s.io/kpng/backends/iptables/util"
 )
 
 var (
@@ -28,7 +27,7 @@ var (
 )
 
 // MakeChainLine return an iptables-save/restore formatted chain line given a Chain
-func MakeChainLine(chain util.Chain) string {
+func MakeChainLine(chain Chain) string {
 	return fmt.Sprintf(":%s - [0:0]", chain)
 }
 
@@ -36,8 +35,8 @@ func MakeChainLine(chain util.Chain) string {
 // It returns a map of iptables.Chain to []byte where the []byte is the chain line
 // from save (with counters etc.).
 // Note that to avoid allocations memory is SHARED with save.
-func GetChainLines(table util.Table, save []byte) map[util.Chain][]byte {
-	chainsMap := make(map[util.Chain][]byte)
+func GetChainLines(table Table, save []byte) map[Chain][]byte {
+	chainsMap := make(map[Chain][]byte)
 	tablePrefix := []byte("*" + string(table))
 	readIndex := 0
 	// find beginning of table
@@ -66,7 +65,7 @@ func GetChainLines(table util.Table, save []byte) map[util.Chain][]byte {
 			if spaceIndex == -1 {
 				panic(fmt.Sprintf("Unexpected chain line in iptables-save output: %v", string(line)))
 			}
-			chain := util.Chain(line[1:spaceIndex])
+			chain := Chain(line[1:spaceIndex])
 			chainsMap[chain] = line
 		}
 	}

--- a/backends/iptables/util/utils.go
+++ b/backends/iptables/util/utils.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type LineBuffer struct {
+	b bytes.Buffer
+}
+
+// Write takes a list of arguments, each a string or []string, joins all the
+// individual strings with spaces, terminates with newline, and writes to buf.
+// Any other argument type will panic.
+func (buf *LineBuffer) Write(args ...interface{}) {
+	for i, arg := range args {
+		if i > 0 {
+			buf.b.WriteByte(' ')
+		}
+		switch x := arg.(type) {
+		case string:
+			buf.b.WriteString(x)
+		case []string:
+			for j, s := range x {
+				if j > 0 {
+					buf.b.WriteByte(' ')
+				}
+				buf.b.WriteString(s)
+			}
+		default:
+			panic(fmt.Sprintf("unknown argument type: %T", x))
+		}
+	}
+	buf.b.WriteByte('\n')
+}
+
+// WriteBytes writes bytes to buffer, and terminates with newline.
+func (buf *LineBuffer) WriteBytes(bytes []byte) {
+	buf.b.Write(bytes)
+	buf.b.WriteByte('\n')
+}
+
+func (buf *LineBuffer) Reset() {
+	buf.b.Reset()
+}
+
+func (buf *LineBuffer) Bytes() []byte {
+	return buf.b.Bytes()
+}


### PR DESCRIPTION
1) porting latest optimization from kube-proxy
https://github.com/kubernetes/kubernetes/pull/106158

2) Moving common file to iptables/util , so that even ipvs backend can use the common functions.
