### PR TITLE
test_e2e: ci_mode is a variable not cmd

### DIFF
--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -116,7 +116,7 @@ function setup_ginkgo {
 }
 
 function apply_ipvx_fixes {
-    if ci_mode = true ; then
+    if "${ci_mode}" = true ; then
         sudo sysctl -w net.ipv6.conf.all.forwarding=1
         sudo sysctl -w net.ipv4.ip_forward=1
     fi


### PR DESCRIPTION
Fix the issue:
./test_e2e.sh: line 119: ci_mode: command not found

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>