### PR TITLE
go-mod-tidy-all: add validations

### DIFF
--- a/go-mod-tidy-all
+++ b/go-mod-tidy-all
@@ -1,1 +1,34 @@
-for f in $(find -name go.mod); do (cd $(dirname $f) && go mod tidy -compat=1.17); done
+#!/bin/bash
+#
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -compat was introduced in go version 1.17
+#
+MIN_GO_VERSION="1.17"
+
+go_version=$(go version | { read _ _ v _; echo ${v#go}; })
+if [ "$?" != "0" ]; then
+    echo "go is required"
+    exit 1
+fi
+
+if expr "${go_version}" '<' "${MIN_GO_VERSION}" 1>/dev/null; then
+    echo "go ${MIN_GO_VERSION} is required"
+    exit 1
+fi
+
+for f in $(find -name go.mod); do
+    (cd $(dirname $f) && go mod tidy -compat="${MIN_GO_VERSION}");
+done


### PR DESCRIPTION
Check if go bin exists and if it's the version
that introduced -compat for go mod tidy.

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>