### PR TITLE
e2e: add initial support to multiple CNI

### DIFF
--- a/hack/kindYAMLTemplate/kindnet/.gitignore
+++ b/hack/kindYAMLTemplate/kindnet/.gitignore
@@ -1,0 +1,1 @@
+kindConfig.yaml

--- a/hack/kindYAMLTemplate/kindnet/kindConfig.yaml.tmpl
+++ b/hack/kindYAMLTemplate/kindnet/kindConfig.yaml.tmpl
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: "${E2E_IP_FAMILY}"
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker


### PR DESCRIPTION
PLEASE NOTE: this branch is based in the PR: #169 (require merge first)

Testing KPNG with multiple CNI will increase the number of people
in the adoption road.
    
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>
