### PR TITLE
e2e_export_logs: remove warning message

### DIFF
--- a/hack/e2e_export_logs.sh
+++ b/hack/e2e_export_logs.sh
@@ -23,4 +23,4 @@ E2E_DIR="$(pwd)/temp/e2e/"
 popd > /dev/null
 E2E_FILE="${E2E_DIR}/clustername"
 E2E_LOGS="${E2E_DIR}/artifacts/logs"
-kind export logs --name="$(cat $E2E_FILE)" --loglevel="debug" "${E2E_LOGS}"
+kind export logs --name="$(cat $E2E_FILE)" -v=3 "${E2E_LOGS}"

--- a/hack/e2e_export_logs.sh
+++ b/hack/e2e_export_logs.sh
@@ -19,8 +19,9 @@
 
 set -e
 pushd "${0%/*}" > /dev/null
-E2E_DIR="$(pwd)/temp/e2e/"
+E2E_DIR="$(pwd)/temp/e2e"
 popd > /dev/null
-E2E_FILE="${E2E_DIR}/clustername"
+CLUSTERNAME=$(kind get clusters | head -1)
+E2E_FILE="${E2E_DIR}/${CLUSTERNAME}"
 E2E_LOGS="${E2E_DIR}/artifacts/logs"
-kind export logs --name="$(cat $E2E_FILE)" -v=3 "${E2E_LOGS}"
+kind export logs --name="${CLUSTERNAME}" -v=3 "${E2E_LOGS}"


### PR DESCRIPTION
WARNING: --loglevel is deprecated, please switch to -v and -q!

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>