### PR TITLE
Default value for masqueradeAll flag for iptables

### DIFF
--- a/backends/iptables/iptables.go
+++ b/backends/iptables/iptables.go
@@ -2,6 +2,7 @@ package iptables
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"net"
 	"strconv"
@@ -22,13 +23,14 @@ import (
 )
 
 var (
-	flag = &pflag.FlagSet{}
-
-	OnlyOutput = flag.Bool("only-output", false, "Only output the ipvsadm-restore file instead of calling ipvsadm-restore")
+	onlyOutput    bool
+	masqueradeAll bool
 )
 
 func BindFlags(flags *pflag.FlagSet) {
-	flags.AddFlagSet(flag)
+	flag.BoolVar(&onlyOutput, "only-output", false, "Only output the ipvsadm-restore file instead of calling ipvsadm-restore")
+	flag.BoolVar(&masqueradeAll, "masquerade-all", false, "Set this flag to set the masq rule for all traffic")
+
 }
 
 type iptables struct {
@@ -101,7 +103,7 @@ func NewIptables() *iptables {
 		natChains:                util.LineBuffer{},
 		natRules:                 util.LineBuffer{},
 		portsMap:                 make(map[utilnet.LocalPort]utilnet.Closeable),
-		masqueradeAll:            false,
+		masqueradeAll:            masqueradeAll,
 		masqueradeMark:           fmt.Sprintf("%#08x", masqueradeValue),
 		localDetector:            NewNoOpLocalDetector(),
 	}

--- a/backends/iptables/iptables.go
+++ b/backends/iptables/iptables.go
@@ -101,7 +101,7 @@ func NewIptables() *iptables {
 		natChains:                util.LineBuffer{},
 		natRules:                 util.LineBuffer{},
 		portsMap:                 make(map[utilnet.LocalPort]utilnet.Closeable),
-		masqueradeAll:            true,
+		masqueradeAll:            false,
 		masqueradeMark:           fmt.Sprintf("%#08x", masqueradeValue),
 		localDetector:            NewNoOpLocalDetector(),
 	}


### PR DESCRIPTION
Setting the default value to false.
A default value of true implied that all requests are snat-d which
prevented from preserving the source ip even for traffic from within the
cluster.

Fixes #162 