### PR TITLE
Fixing DeleteIPPort API with currentSvc object

### DIFF
--- a/client/serviceevents/service-events.go
+++ b/client/serviceevents/service-events.go
@@ -182,7 +182,7 @@ func (sl *ServicesListener) diff(prevSvc, currSvc *localnetv1.Service) {
 				},
 				Added:   func(ci int) { sl.IPPortsListener.AddIPPort(currSvc, currs[ci].ip, ext.ipKind, currs[ci].port) },
 				Updated: func(_, _ int) {},
-				Deleted: func(pi int) { sl.IPPortsListener.DeleteIPPort(prevSvc, prevs[pi].ip, ext.ipKind, prevs[pi].port) },
+				Deleted: func(pi int) { sl.IPPortsListener.DeleteIPPort(currSvc, prevs[pi].ip, ext.ipKind, prevs[pi].port) },
 			}.SlicesLen(len(prevs), len(currs))
 		}
 	}


### PR DESCRIPTION
In below DeleteIPPort API, svc object carries incorrect info.

`DeleteIPPort(svc *localnetv1.Service, ip string, ipKind IPKind, port *localnetv1.PortMapping)`

Lets see the following sequence of events:

a) Create service-A with port-A. So the svc object, will have port-A info.
b) Create endpoint
c) Update service-A with port-B. So the svc object, will have port-B info in addition to port-A.
d) Remove port-B and update service-A. Now `DeleteIPPort` is invoked with svc object having both port-A,port-B. 
Anyway the deleted port i.e port-B is passed as parameter.

Backends storing svc object will get into trouble especially during EP addition/deletion.
Backends end up reading stale svc object with incorrect info.

Other options for backend is that , they need to store port info rather than caching svc object.
