### PR TITLE
fail kpng local up if compilation is broken

### DIFF
--- a/hack/kpng-local-up.sh
+++ b/hack/kpng-local-up.sh
@@ -33,7 +33,12 @@ read
 function build_kpng {
     cd ../
 
-    docker build -t $IMAGE ./
+    if docker build -t $IMAGE ./ ; then
+	echo "passed build"
+    else
+	echo "failed build"
+        exit 123
+    fi
     docker push $IMAGE
     cd hack/
 }


### PR DESCRIPTION
essential MR to fix the fact that kpng-local-up fails silently ... 

fixes #212 