### PR TITLE
make: add support for build multi-arch bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /tmp
 *~
 modd.conf
+kpng-bin

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@
 
 all: help
 
+# kpng build info
+VERSION=$(shell git describe --tags --always --long)
+LDFLAGS="-s -w -X main.version=$(VERSION)"
+ARCH="amd64"
+BUILD_DIR="kpng-bin"
+export PLATFORM=""
+
 # Auto Generate help from: https://gist.github.com/prwhite/8168133
 # COLORS
 GREEN  := $(shell tput -Txterm setaf 2)
@@ -109,3 +116,35 @@ e2e: e2e-ipv4-iptables \
 	e2e-ipv4-nft \
 	e2e-ipv6-nft \
 	e2e-dual-nft
+
+## Build binary for Windows platform
+windows: PLATFORM="windows"
+windows:
+	@$(MAKE) -e build
+
+## Build binary for Linux platform
+linux: PLATFORM="linux"
+linux:
+	@$(MAKE) -e build
+
+## Build binary for Darwin platform
+darwin: PLATFORM="darwin"
+darwin:
+	@$(MAKE) -e build
+
+build:
+	@mkdir -p $(BUILD_DIR)/$(PLATFORM)/$(VERSION)
+	@cd cmd && \
+		env GOOS=$(PLATFORM) \
+		GOARCH=$(ARCH) \
+		go build \
+		-trimpath \
+		-o ../$(BUILD_DIR)/$(PLATFORM)/$(VERSION) \
+		-v \
+		-ldflags=$(LDFLAGS) \
+		./...
+	@echo "\tkpng $(YELLOW)$(PLATFORM)$(RESET) binaries available in: $(GREEN)$(BUILD_DIR)/$(PLATFORM)/$(VERSION)$(RESET)\n"
+
+## Build binary for all supported platforms
+release: linux windows darwin
+	@echo "\nAll release binaries are available in: $(YELLOW)$(BUILD_DIR)$(RESET)/\n"


### PR DESCRIPTION
This patch adds:
<pre>
     make windows - build windows binary
     make linux - build linux binary
     make darwin - build darwin binary
     make release - build all supported platforms
</pre>
- All binaries will be generated in kpng-bin/
- Addionatly, it sets VERSION (Now kpng version works).

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>