### PR TITLE
Fix external ip panic on no endpoints

### DIFF
--- a/backends/iptables/iptables.go
+++ b/backends/iptables/iptables.go
@@ -463,7 +463,7 @@ func (t *iptables) writeExternalIPRules(svcInfo *serviceInfo, svcName types.Name
 				"-A", string(kubeExternalServicesChain),
 				"-m", "comment", "--comment", fmt.Sprintf(`"%s has no endpoints"`, svcInfo.serviceNameString),
 				"-m", protocol, "-p", protocol,
-				"-d", net.ParseIP(externalIP),
+				"-d", ToCIDR(net.ParseIP(externalIP)),
 				"--dport", strconv.Itoa(svcInfo.Port()),
 				"-j", "REJECT",
 			)


### PR DESCRIPTION
This fixes iptables backend panic while programming iptable rules for external IP when there are no endpoints .