### PR TITLE
Enhancing service events for traffic policy and session affinity

### DIFF
--- a/backends/ipvs-as-sink/ipvs.go
+++ b/backends/ipvs-as-sink/ipvs.go
@@ -122,7 +122,29 @@ func (s *Backend) DeleteIP(svc *localnetv1.Service, ip string, ipKind serviceeve
 	s.deleteServiceIPToKubeIPVSIntf(ip)
 }
 
-// -------------------------------------------------------------------------
+// Handle session affinity
+var _ serviceevents.SessionAffinityListener = &Backend{}
+
+func (s *Backend) EnableSessionAffinity(svc *localnetv1.Service, sessionAffinity serviceevents.SessionAffinity) {
+	klog.V(2).Infof("EnableSessionAffinity (svc: %v, sessionAffinity: %v)", svc, sessionAffinity)
+}
+
+func (s *Backend) DisableSessionAffinity(svc *localnetv1.Service) {
+	klog.V(2).Infof("DisableSessionAffinity (svc: %v,)", svc)
+}
+
+// Handle traffic policy
+var _ serviceevents.TrafficPolicyListener = &Backend{}
+
+func (s *Backend) EnableTrafficPolicy(svc *localnetv1.Service, policyKind serviceevents.TrafficPolicyKind) {
+	klog.V(2).Infof("EnableTrafficPolicy (svc: %v, policyKind: %v)", svc, policyKind)
+}
+
+func (s *Backend) DisableTrafficPolicy(svc *localnetv1.Service, policyKind serviceevents.TrafficPolicyKind) {
+	klog.V(2).Infof("DisableTrafficPolicy (svc: %v, policyKind: %v)", svc, policyKind)
+}
+
+// SetService ------------------------------------------------------
 // Service
 //
 func (s *Backend) SetService(svc *localnetv1.Service) {}

--- a/client/serviceevents/traffic_policy_kind.go
+++ b/client/serviceevents/traffic_policy_kind.go
@@ -1,0 +1,12 @@
+package serviceevents
+
+// TrafficPolicyKind decribes the type of traffic policy received by TrafficPolicyListener
+type TrafficPolicyKind int
+
+const (
+	TrafficPolicyInternal TrafficPolicyKind = iota
+	TrafficPolicyExternal
+)
+
+//go:generate stringer -type=TrafficPolicyKind
+// reminder: to get stringer: go install golang.org/x/tools/cmd/stringer

--- a/client/serviceevents/wrap.go
+++ b/client/serviceevents/wrap.go
@@ -38,6 +38,12 @@ func Wrap(backend decoder.Interface) decoder.Interface {
 	if v, ok := backend.(IPPortsListener); ok {
 		l.IPPortsListener = v
 	}
+	if v, ok := backend.(SessionAffinityListener); ok {
+		l.SessionAffinityListener = v
+	}
+	if v, ok := backend.(TrafficPolicyListener); ok {
+		l.TrafficPolicyListener = v
+	}
 
 	wrap := wrapper{
 		Interface: backend,


### PR DESCRIPTION
This code change enhances `client/serviceevents/service-events.go` to provide API's for `TrafficPolicy(Internal/External)` and `sessionAffinity`. IPVS currently uses filter reset + service events.

IPVS Backend code handling these events will be raised in subsequent patch.

#215 

Mikael's suggestion is to use fullstate + diffstore for IPVS. We will explore this option as well, if performance numbers for above design are pathetic .


