### PR TITLE
EndpointPortMap update fix

### DIFF
--- a/server/jobs/kube2store/slice-event-handler.go
+++ b/server/jobs/kube2store/slice-event-handler.go
@@ -72,12 +72,11 @@ func (h sliceEventHandler) OnAdd(obj interface{}) {
 			info.Endpoint.AddAddress(addr)
 		}
 
+		epMap := make(map[string]int32, len(eps.Ports))
 		for _, port := range eps.Ports {
-			ep := map[string]int32{
-				*port.Name: *port.Port,
-			}
-			info.Endpoint.EndpointPortMap = ep
+			epMap[*port.Name] = *port.Port
 		}
+		info.Endpoint.EndpointPortMap = epMap
 
 		infos = append(infos, info)
 	}


### PR DESCRIPTION
Fixes #241 

Instead of choosing only the last port, we need to assign all `port names: numbers` to the endpoint port map.