### PR TITLE
test_e2e: fix to make ipv6 tests run correctly (or detect incompatible sysctl settings)

### DIFF
--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -981,7 +981,7 @@ function main {
     if [ "${cluster_count}" -eq "1" ] ; then
         local tmp_suffix=${suffix:+"-${suffix}"}
         create_infrastructure_and_run_tests "${e2e_dir}${tmp_suffix}" "${ip_family}" "${backend}" \
-              "${tmp_suffix}" "${devel_mode}" "${ci_mode}"
+              "${bin_dir}/e2e.test" "${tmp_suffix}" "${devel_mode}" "${ci_mode}"
     else
         local pids
 

--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -621,8 +621,8 @@ function set_sysctl {
    if_error_exit "\"sysctl -n ${attribute}\" failed"
 
    if [ ! "${value}" -eq "${result}" ] ; then
-       echo "Setting: \"sysctl -w ${attribute} = ${value}\""
-       sudo sysctl -w  "${attribute}" = "${value}"
+       echo "Setting: \"sysctl -w ${attribute}=${value}\""
+       sudo sysctl -w  "${attribute}"="${value}"
        if_error_exit "\"sudo sysctl -w  ${attribute} = ${value}\" failed"
    fi
 }


### PR DESCRIPTION
Added code that verify the host network settings and also code that set them if ci/cd is set.

Made delete of clusters used for test default behaviour
Small changes in ginko settings in test_run
Prepared for changes in how kind cluster is created