### PR TITLE
Implementing http endpoint to query the backend

### DIFF
--- a/backends/ipvs-as-sink/go.mod
+++ b/backends/ipvs-as-sink/go.mod
@@ -9,6 +9,7 @@ require (
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
+    k8s.io/apiserver v0.24.1
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/kpng/api v0.0.0-20220521134046-f747cedbe766


### PR DESCRIPTION
E2E testcases for session affinity check for the type of backend i.e ipvs or iptable. This check is to decide the expiry time of session affinity. For IPVS , the minimum time is 120sec.