### PR TITLE
Fix cleanup of stale conntrack entires to make UDP NodePort services work properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 /tmp
 *~
 modd.conf
-temp
-.vscode
+temp/
+.vscode/

--- a/client/plugins/conntrack/conntrack_linux.go
+++ b/client/plugins/conntrack/conntrack_linux.go
@@ -20,7 +20,7 @@ func setupConntrack() {
 
 func cleanupIPPortEntries(ipp IPPort) {
 	parameters := parametersWithFamily(utilnet.IsIPv6String(ipp.DnatIP), "-D",
-		"-p", protoStr(ipp.Protocol), "--sport", strconv.Itoa(int(ipp.Port)))
+		"-p", protoStr(ipp.Protocol), "--dport", strconv.Itoa(int(ipp.Port)))
 	if ipp.DnatIP != "node" {
 		parameters = append(parameters, "--orig-dst", ipp.DnatIP)
 	}

--- a/client/plugins/conntrack/conntrack_test.go
+++ b/client/plugins/conntrack/conntrack_test.go
@@ -71,8 +71,8 @@ func ExampleConntrack() {
 
 	// Output:
 	// -- initial state --
-	// /bin/conntrack [-D -p tcp --sport 80 --orig-dst 10.1.1.1]
-	// /bin/conntrack [-D -p udp --sport 53 --orig-dst 10.1.1.1]
+	// /bin/conntrack [-D -p tcp --dport 80 --orig-dst 10.1.1.1]
+	// /bin/conntrack [-D -p udp --dport 53 --orig-dst 10.1.1.1]
 	// -- add one endpoint --
 	// -- remove one endpoint --
 	// /bin/conntrack [-D -p udp --dport 53 --dst-nat 10.1.3.1 --orig-dst 10.1.1.1]


### PR DESCRIPTION
This should fix the e2e test `[It] should be able to preserve UDP traffic when server pod cycles for a NodePort service` for nft backend and help close #174 