### PR TITLE
Fix masquerading in NFT backend

### DIFF
--- a/backends/nft/nft.go
+++ b/backends/nft/nft.go
@@ -265,6 +265,7 @@ func addPostroutingChain(table *nftable, clusterCIDRs []string, localEndpointIPs
 		if hasLocalEPs {
 			fmt.Fprint(chain, "  ", table.Family, " daddr != { ", strings.Join(localEndpointIPs, ", "), " } \\\n")
 		}
+		fmt.Fprint(chain, "  fib daddr type != local \\\n")
 		fmt.Fprint(chain, "  masquerade\n")
 	}
 

--- a/backends/nft/render-context_test.go
+++ b/backends/nft/render-context_test.go
@@ -125,6 +125,7 @@ func ExampleRenderBasicService() {
 	//   # masquerade non-cluster traffic to non-local endpoints
 	//   ip saddr != { 10.1.0.0/16 } \
 	//   ip daddr != { 10.1.0.1, 10.1.0.2 } \
+	//   fib daddr type != local \
 	//   masquerade
 	//
 	//   # masquerade hairpin traffic
@@ -239,6 +240,7 @@ func ExampleRenderServiceWithClientIPAffinity() {
 	//   # masquerade non-cluster traffic to non-local endpoints
 	//   ip saddr != { 10.1.0.0/16 } \
 	//   ip daddr != { 10.1.0.1, 10.1.0.2 } \
+	//   fib daddr type != local \
 	//   masquerade
 	//
 	//   # masquerade hairpin traffic

--- a/hack/kpng-deployment-ds.yaml.tmpl
+++ b/hack/kpng-deployment-ds.yaml.tmpl
@@ -38,11 +38,7 @@ spec:
           mountPath: /k8s
         - mountPath: /var/lib/kpng
           name: kpng-config
-        args:
-        - kube
-        - --kubeconfig=/var/lib/kpng/kubeconfig.conf
-        - to-api
-        - --listen=unix:///k8s/proxy.sock
+        args: ['kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-api', '--listen=${KPNG_SERVER_ADDRESS}']
       - image: ${IMAGE}
         imagePullPolicy: ${PULL}
         env:
@@ -57,8 +53,7 @@ spec:
         - name: modules
           mountPath: /lib/modules
           readOnly: true
-        args: [ "local", "--api=unix:///k8s/proxy.sock", "to-${E2E_BACKEND}", "--v=${KPNG_DEBUG_LEVEL}"]
-        #- --dry-run
+        args: ${E2E_BACKEND_ARGS}
       volumes:
       - name: empty
         emptyDir: {}

--- a/hack/kpng-local-up.sh
+++ b/hack/kpng-local-up.sh
@@ -19,9 +19,9 @@
 # TODO Replace with 1.22 once we address 
 #: ${KIND:="kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"}
 : ${KIND:="kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047"}
-: ${IMAGE:="jayunit100/kpng:2"}
-: ${PULL:=IfNotPresent}
-: ${E2E_BACKEND:=userspacelin}
+: ${IMAGE:="gauravkghildiyal/kpng:latest"}
+: ${PULL:="IfNotPresent"}
+: ${E2E_BACKEND:="nft"}
 : ${CONFIG_MAP_NAME:=kpng}
 : ${SERVICE_ACCOUNT_NAME:=kpng}
 : ${NAMESPACE:=kube-system}
@@ -29,7 +29,7 @@
 
 export IMAGE PULL E2E_BACKEND CONFIG_MAP_NAME SERVICE_ACCOUNT_NAME NAMESPACE KPNG_DEBUG_LEVEL
 
-echo -n "this will deploy kpng with docker image $IMAGE, pull policy $PULL and the $BACKEND backend. Press enter to confirm, C-c to cancel"
+echo -n "this will deploy kpng with docker image $IMAGE, pull policy '$PULL' and the '$E2E_BACKEND' backend. Press enter to confirm, C-c to cancel"
 read
 
 function build_kpng {


### PR DESCRIPTION
This should fix the persistent test flakes observed in the following e2e tests (when run against the nft backend):
* `should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance] `
* `should have session affinity timeout work for NodePort service [LinuxOnly] [Conformance] `
* `should have session affinity work for NodePort service [LinuxOnly] [Conformance] `

Changes include:
* Preventing the masquerading of local traffic directly within the host
* Configuring the correct `CLUSTER_CIDR` values so that the *rest of the values* are masqueraded.