### PR TITLE
Include example in go.work

### DIFF
--- a/go.work
+++ b/go.work
@@ -10,5 +10,9 @@ use (
 	./backends/windows/userspace
 	./client
 	./cmd
+	./examples/iptables-extip
+	./examples/pipe-exec
+	./examples/print-state
+	./examples/userspace-proxier
 	./server
 )

--- a/hack/go-build
+++ b/hack/go-build
@@ -1,2 +1,3 @@
 set -ex
-CGO_ENABLED=1 go build -trimpath -o dist $(hack/go-list-local-mods)
+test -n "$VERSION" || VERSION=$(git describe --dirty --tags)
+CGO_ENABLED=1 go build -trimpath -o dist -ldflags "-X main.version=$VERSION" $(hack/go-list-local-mods)


### PR DESCRIPTION
The `examples/` items should be included in `go.work`, else they can't be built.

Also use $VERSION in binaries. I not set the version defaults to the output from;
```
git describe --dirty --tags
```

I myself becomed very annoyed if I can't get the version of programs I am using and I assume I am not alone.
