### PR TITLE
discovery.k8s.io/v1beta1 -> v1

### DIFF
--- a/backends/iptables/endpoints.go
+++ b/backends/iptables/endpoints.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"

--- a/server/jobs/kube2store/kube2store.go
+++ b/server/jobs/kube2store/kube2store.go
@@ -99,7 +99,7 @@ func (j Job) Run(ctx context.Context) {
 	}
 
 	if j.Config.UseSlices {
-		slicesInformer := factory.Discovery().V1beta1().EndpointSlices().Informer()
+		slicesInformer := factory.Discovery().V1().EndpointSlices().Informer()
 		slicesInformer.AddEventHandler(&sliceEventHandler{j.eventHandler(slicesInformer)})
 		go slicesInformer.Run(stopCh)
 

--- a/server/jobs/kube2store/slice-event-handler.go
+++ b/server/jobs/kube2store/slice-event-handler.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kube2store
 
 import (
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/klog/v2"
 
 	localnetv1 "sigs.k8s.io/kpng/api/localnetv1"
@@ -51,13 +51,8 @@ func (h sliceEventHandler) OnAdd(obj interface{}) {
 			Namespace:   eps.Namespace,
 			ServiceName: serviceName,
 			SourceName:  eps.Name,
-			Topology:    sliceEndpoint.Topology,
 			Endpoint:    &localnetv1.Endpoint{},
 			Conditions:  &localnetv1.EndpointConditions{},
-		}
-
-		if sliceEndpoint.Topology != nil {
-			info.NodeName = sliceEndpoint.Topology[hostNameLabel]
 		}
 
 		if h := sliceEndpoint.Hostname; h != nil {
@@ -88,7 +83,7 @@ func (h sliceEventHandler) OnAdd(obj interface{}) {
 		if log := klog.V(3); log.Enabled() {
 			log.Info("endpoints of ", eps.Namespace, "/", serviceName, ":")
 			tx.EachEndpointOfService(eps.Namespace, serviceName, func(ei *localnetv1.EndpointInfo) {
-				log.Info("- ", ei.Endpoint.IPs, " | topo: ", ei.Topology)
+				log.Info("- ", ei.Endpoint.IPs)
 			})
 		}
 	})


### PR DESCRIPTION
The v1beta1 version is removed in K8s v1.25+
```
W0724 12:25:51.279069     951 warnings.go:70] discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21+, unavailable in v1.25+; use discovery.k8s.io/v1 EndpointSlice
```

The `Topology` field is removed. I don't know the impact, I just removed it.
