### PR TITLE
WIP Build and run KPNG in Windows containers

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -2,8 +2,10 @@ FROM --platform=linux/amd64 golang:1.18.4 as build
 WORKDIR /src/
 COPY . /src/
 RUN VERSION=latest GOFLAGS="-buildvcs=false" make windows
+RUN curl -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
 
 FROM --platform=windows/amd64 mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v0.1.0
 COPY --from=build /src/kpng-bin/windows/latest/* /
+COPY --from=build /src/hns.psm1 /
 ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
 ENTRYPOINT ["kpng.exe"]

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -7,5 +7,7 @@ RUN curl -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/w
 FROM --platform=windows/amd64 mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v0.1.0
 COPY --from=build /src/kpng-bin/windows/latest/* /
 COPY --from=build /src/hns.psm1 /
+COPY --from=build /src/examples/windows/start-kpng.ps1 /
 ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
+WORKDIR /hpc/
 ENTRYPOINT ["kpng.exe"]

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,0 +1,9 @@
+FROM --platform=linux/amd64 golang:1.18.4 as build
+WORKDIR /src/
+COPY . /src/
+RUN VERSION=latest GOFLAGS="-buildvcs=false" make windows
+
+FROM --platform=windows/amd64 mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v0.1.0
+COPY --from=build /src/kpng-bin/windows/latest/* /
+ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
+ENTRYPOINT ["kpng.exe"]

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 all: help
 
 # kpng build info
-VERSION=$(shell git describe --tags --always --long)
+VERSION?=$(shell git describe --tags --always --long)
 LDFLAGS="-X main.version=$(VERSION)"
 ARCH="amd64"
 BUILD_DIR="kpng-bin"

--- a/examples/windows/kpng-rbac.yaml
+++ b/examples/windows/kpng-rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kpng
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kpng
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kpng
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kpng
+subjects:
+- kind: ServiceAccount
+  name: kpng
+  namespace: kube-system
+

--- a/examples/windows/kpng-windows.yaml
+++ b/examples/windows/kpng-windows.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kpng
+  name: kpng-windows
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kpng-windows
+  template:
+    metadata:
+      labels:
+        k8s-app: kpng-windows
+        namespace: kube-system
+    spec:
+      serviceAccountName: kpng
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      containers:
+      - image: mrosse3/kpng:latest
+        imagePullPolicy: Always # for testing
+        name: kpng-kube-to-api
+        args: ["kube", "to-api","-v=4"]
+        # override Kubernetes service env vars to talk to api-server via
+        # CP node directly since we don't have routes programmed yet.
+        # NOTE: These values are specific to the default CAPZ deployment.
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "10.0.0.4"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "6443"
+        - name: KUBERNETES_SERVICE_PORT_HTTPS
+          value: "6443"
+      nodeSelector:
+        kubernetes.io/os: windows
+      os:
+        name: windows
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - operator: Exists
+  updateStrategy:
+    type: RollingUpdate

--- a/examples/windows/kpng-windows.yaml
+++ b/examples/windows/kpng-windows.yaml
@@ -40,6 +40,11 @@ spec:
         imagePullPolicy: Always # for testing
         name: kpng-local-to-winkernel
         command: ["powershell", "./start-kpng.ps1"]
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
       nodeSelector:
         kubernetes.io/os: windows
       os:

--- a/examples/windows/kpng-windows.yaml
+++ b/examples/windows/kpng-windows.yaml
@@ -36,6 +36,10 @@ spec:
           value: "6443"
         - name: KUBERNETES_SERVICE_PORT_HTTPS
           value: "6443"
+      - image: mrosse3/kpng:latest
+        imagePullPolicy: Always # for testing
+        name: kpng-local-to-winkernel
+        command: ["powershell", "./start-kpng.ps1"]
       nodeSelector:
         kubernetes.io/os: windows
       os:

--- a/examples/windows/start-kpng.ps1
+++ b/examples/windows/start-kpng.ps1
@@ -11,12 +11,13 @@ while (-Not (Get-HnsNetwork | ? Name -EQ $NetworkName)) {
 }
 Write-Host "Found HNS network '$NetworkName'"
 
-# TODO: add node-ip and cluster-cidr here once those values are exposed as flags
+# TODO: and enable-dsr??
 $argList = @(`
     "local", `
     "to-winkernel", `
-    "-v=4"`
-#    "--enable-dsr=true" TODO expose this as a flag..
+    "-v=4", `
+    "--cluster-cidr=10.96.0.0/12", `
+    "--nodeip=${env:NODE_IP}" `
 )
 
 Write-Host "Getting source vip"
@@ -29,7 +30,7 @@ if ($network.Type -EQ "Overlay") {
     }
     $sourceVip = (Get-HnsEndpoint | ? Name -EQ "${NetworkName}_ep").IpAddress
     Write-Host "Host endpoint found. Source VIP: $sourceVip"
-    # $argList += "--source-vip=$sourceVip" -- right now this is hard-coded :'(
+    $argList += "--source-vip=$sourceVip"
 }
 
 Start-Sleep 5 # wait for kube to-api to start?

--- a/examples/windows/start-kpng.ps1
+++ b/examples/windows/start-kpng.ps1
@@ -1,0 +1,38 @@
+$ErrorActionPrefernce = "Stop"
+
+Write-Host "Importing hns.pms1"
+Import-Module .\hns.psm1
+
+$NetworkName = "Calico"
+Write-Host "Waiting for network '$NetworkName' to be available..."
+while (-Not (Get-HnsNetwork | ? Name -EQ $NetworkName)) {
+    Write-Debug "Still waiting for HNS network..."
+    Start-Sleep 5
+}
+Write-Host "Found HNS network '$NetworkName'"
+
+# TODO: add node-ip and cluster-cidr here once those values are exposed as flags
+$argList = @(`
+    "local", `
+    "to-winkernel", `
+    "-v=4"`
+#    "--enable-dsr=true" TODO expose this as a flag..
+)
+
+Write-Host "Getting source vip"
+
+$network = (Get-HnsNetwork | ? Name -EQ $NetworkName)
+if ($network.Type -EQ "Overlay") {
+    Write-Host "Overlay / VXLAN network detected... waiting for host endpoint to be created..."
+    while (-not (Get-HnsEndpoint | ? Name -EQ "${NetworkName}_ep")) {
+        Start-Sleep 1
+    }
+    $sourceVip = (Get-HnsEndpoint | ? Name -EQ "${NetworkName}_ep").IpAddress
+    Write-Host "Host endpoint found. Source VIP: $sourceVip"
+    # $argList += "--source-vip=$sourceVip" -- right now this is hard-coded :'(
+}
+
+Start-Sleep 5 # wait for kube to-api to start?
+
+$env:KUBE_NETWORK=$NetworkName
+Invoke-Expression "c:\hpc\kpng.exe $argList"

--- a/hack/build_windows_container.sh
+++ b/hack/build_windows_container.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+: ${REPOSITORY?"Need to REPOSITORY"}
+TAG=${tag:-"latest"}
+
+docker buildx create --name img-builder --use --platform windows/amd64
+trap 'docker builx rm img-builder' EXIT
+
+docker buildx build --platform windows/amd64 --output=type=registry --pull -f Dockerfile.Windows -t $REPOSITORY/kpng:$TAG .


### PR DESCRIPTION
I'm working on running using KPNG instead of kube-proxy in a CAPZ cluster.
This PR adds 
- files needed to build a windows container image w/ kpng and files needed to start it
- deployment files for running kpng in a cluster on windows nodes.

I have this running on a CAPZ cluster!

In order to make more progress here several hard-coded values (--source-vip, --enable-dsr, --node-ip, --cluster-cidr) need to be exposed as flags for the winkernel backend.
I'll try and work on that as a separate PR.

Note - this is very much a WIP. We shouldn't be running `kube to-api` on every node but this was the easiest path forward for me :)