### PR TITLE
Remove reference to endpoint's type

### DIFF
--- a/backends/windows/kernelspace/endpoints.go
+++ b/backends/windows/kernelspace/endpoints.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"


### PR DESCRIPTION
Remove this reference so that we
don't get deprocation warnings.

It's only used for

```
string(discovery.AddressTypeIPv4),
string(discovery.AddressTypeIPv6),
```

Which is an type still included in
v1 of the API.

Should fix #339 