### PR TITLE
Update kpng-local-up.sh and fix potential IPVS panic

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -16,12 +16,7 @@ jobs:
     - name: setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17.3'
-
-    - name: Install dependencies
-      run: |
-        go version
-        go get -u golang.org/x/lint/golint
+        go-version: '1.18.6'
 
   iptables:
     name: build backend package iptables
@@ -66,4 +61,4 @@ jobs:
     
     - name: build backends/ebpf
       run: ./hack/test_backend_build.sh ebpf
-      
+

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -8,7 +8,7 @@ on:
       - master
 
 env:
-  GO_VERSION: "1.18.4"
+  GO_VERSION: "1.18.6"
 
 jobs:
   setup:

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -55,7 +55,7 @@ jobs:
           export GOBIN=$(go env GOPATH)/bin
           export PATH=$PATH:$GOBIN
           echo "PATH=$PATH" >> $GITHUB_ENV
-          go install github.com/cilium/ebpf/cmd/bpf2go@master
+          go install github.com/cilium/ebpf/cmd/bpf2go@v0.9.2
           sudo apt-get install -y clang llvm libelf-dev libpcap-dev gcc-multilib build-essential
         fi 
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.18.2'
+        go-version: '1.18.6'
         stable: 'false'
 
     - name: Install dependencies

--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -275,7 +275,7 @@ function setup_bpf2go() {
 	#remove GOPATH just to be sure
 	export GOPATH=""
 	
-        go install github.com/cilium/ebpf/cmd/bpf2go@master
+        go install github.com/cilium/ebpf/cmd/bpf2go@v0.9.2
         if_error_exit "cannot install bpf2go"
 
 	pass_message "The tool bpf2go is installed. at: $(which bpf2go)"

--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -60,23 +60,7 @@ GINKGO_PROVIDER="local"
 # Users can specify docker.io, quay.io registry
 KINDEST_NODE_IMAGE="docker.io/kindest/node"
 
-function if_error_exit {
-    ###########################################################################
-    # Description:                                                            #
-    # Validate if previous command failed and show an error msg (if provided) #
-    #                                                                         #
-    # Arguments:                                                              #
-    #   $1 - error message if not provided, it will just exit                 #
-    ###########################################################################
-    if [ "$?" != "0" ]; then
-        if [ -n "$1" ]; then
-            RED="\e[31m"
-            ENDCOLOR="\e[0m"
-            echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
-        fi
-        exit 1
-    fi
-}
+source "${SCRIPT_DIR}"/utils.sh
 
 function if_error_warning {
     ###########################################################################
@@ -93,23 +77,6 @@ function if_error_warning {
             echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
         fi
     fi
-}
-
-function pass_message {
-    ###########################################################################
-    # Description:                                                            #
-    # show [PASSED] in green and a message as the validation passed.          #
-    #                                                                         #
-    # Arguments:                                                              #
-    #   $1 - message to output                                                #
-    ###########################################################################
-    if [ -z "${1}" ]; then
-        echo "pass_message() requires a message"
-        exit 1
-    fi
-    GREEN="\e[32m"
-    ENDCOLOR="\e[0m"
-    echo -e "[ ${GREEN}PASSED${ENDCOLOR} ] ${1}"
 }
 
 function detect_container_engine {
@@ -273,60 +240,6 @@ function setup_ginkgo {
     fi
 
     pass_message "The tools ginko and e2e.test have been set up."
-}
-
-command_exists() {
-    ###########################################################################
-    # Description:                                                            #
-    # Checkt if a binary exists                                               #
-    #                                                                         #
-    # Arguments:                                                              #
-    #   arg1: binary name                                                     #
-    ###########################################################################
-    cmd="$1"
-    command -v "${cmd}" >/dev/null 2>&1
-}
-
-function setup_j2() {
-    ###########################################################################
-    # Description:                                                            #
-    # Install j2 binary                                                       #
-    ###########################################################################
-    if ! command_exists j2 ; then
-	# Add path to pip --user installation directory
-	if [ -d "${HOME}"/.local/bin ] ; then
-           add_to_path "${HOME}"/.local/bin
-	fi
-    fi
-
-    if ! command_exists j2 ; then  
-	if command_exists pip ; then
-            echo "'j2' not found, installing with 'pip'"
-            pip install wheel --user
-            pip freeze | grep j2cli || pip install j2cli[yaml] --user
-            if_error_exit "cannot download j2"
-	elif command_exists python3 ; then
-            echo "'j2' not found, installing with 'python3 -m pip'"
-            python3 -m pip install wheel --user
-            python3 -m pip freeze | grep j2cli || python3 -m pip install j2cli[yaml] --user
-            if_error_exit "cannot download j2"
-	elif command_exists python2 ; then
-            echo "'j2' not found, installing with 'python2 -m pip'"
-            python2 -m pip install wheel --user
-            python2 -m pip freeze | grep j2cli || python2 -m pip install j2cli[yaml] --user
-            if_error_exit "cannot download j2"
-	elif command_exists python ; then
-            echo "'j2' not found, installing with 'python -m pip'"
-            python -m pip install wheel --user
-            python -m pip freeze | grep j2cli || python -m pip install j2cli[yaml] --user
-            if_error_exit "cannot download j2"
-	else
-	    echo "cannot find a tool or python that can downlad j2"
-	    exit 1
-	fi
-        add_to_path "${HOME}"/.local/bin
-	pass_message "The tool j2 is installed."
-    fi
 }
 
 function setup_bpf2go() {

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# shellcheck disable=SC2181,SC2155,SC2128
+#
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function if_error_exit {
+    ###########################################################################
+    # Description:                                                            #
+    # Validate if previous command failed and show an error msg (if provided) #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   $1 - error message if not provided, it will just exit                 #
+    ###########################################################################
+    if [ "$?" != "0" ]; then
+        if [ -n "$1" ]; then
+            RED="\e[31m"
+            ENDCOLOR="\e[0m"
+            echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
+        fi
+        exit 1
+    fi
+}
+
+function pass_message {
+    ###########################################################################
+    # Description:                                                            #
+    # show [PASSED] in green and a message as the validation passed.          #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   $1 - message to output                                                #
+    ###########################################################################
+    if [ -z "${1}" ]; then
+        echo "pass_message() requires a message"
+        exit 1
+    fi
+    GREEN="\e[32m"
+    ENDCOLOR="\e[0m"
+    echo -e "[ ${GREEN}PASSED${ENDCOLOR} ] ${1}"
+}
+
+function add_to_path {
+    ###########################################################################
+    # Description:                                                            #
+    # Add directory to path                                                   #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   arg1:  directory                                                      #
+    ###########################################################################
+    [ $# -eq 1 ]
+    if_error_exit "Wrong number of arguments to ${FUNCNAME[0]}"
+
+    local directory="${1}"
+
+    [ -d "${directory}" ]
+    if_error_exit "Directory \"${directory}\" does not exist"
+
+    case ":${PATH:-}:" in
+        *:${directory}:*) ;;
+        *) PATH="${directory}${PATH:+:$PATH}" ;;
+    esac
+}
+
+command_exists() {
+    ###########################################################################
+    # Description:                                                            #
+    # Checkt if a binary exists                                               #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   arg1: binary name                                                     #
+    ###########################################################################
+    cmd="$1"
+    command -v "${cmd}" >/dev/null 2>&1
+}
+
+function setup_j2() {
+    ###########################################################################
+    # Description:                                                            #
+    # Install j2 binary                                                       #
+    ###########################################################################
+    if ! command_exists j2 ; then
+	# Add path to pip --user installation directory
+	if [ -d "${HOME}"/.local/bin ] ; then
+           add_to_path "${HOME}"/.local/bin
+	fi
+    fi
+
+    if ! command_exists j2 ; then
+	if command_exists pip ; then
+            echo "'j2' not found, installing with 'pip'"
+            pip install wheel --user
+            pip freeze | grep j2cli || pip install j2cli[yaml] --user
+            if_error_exit "cannot download j2"
+	elif command_exists python3 ; then
+            echo "'j2' not found, installing with 'python3 -m pip'"
+            python3 -m pip install wheel --user
+            python3 -m pip freeze | grep j2cli || python3 -m pip install j2cli[yaml] --user
+            if_error_exit "cannot download j2"
+	elif command_exists python2 ; then
+            echo "'j2' not found, installing with 'python2 -m pip'"
+            python2 -m pip install wheel --user
+            python2 -m pip freeze | grep j2cli || python2 -m pip install j2cli[yaml] --user
+            if_error_exit "cannot download j2"
+	elif command_exists python ; then
+            echo "'j2' not found, installing with 'python -m pip'"
+            python -m pip install wheel --user
+            python -m pip freeze | grep j2cli || python -m pip install j2cli[yaml] --user
+            if_error_exit "cannot download j2"
+	else
+	    echo "cannot find a tool or python that can downlad j2"
+	    exit 1
+	fi
+        add_to_path "${HOME}"/.local/bin
+	pass_message "The tool j2 is installed."
+    fi
+}
+


### PR DESCRIPTION
While trying to run the project locally using `hack/kpng-local-up.sh`, I encountered several problems:
* Using the ipvs backend used to cause a panic, because the base distro being used in the kind node was out of date hence there was no `proc/sys/net/ipv4/vs` present, resulting in `Setup()` to fail silently. Later when a new service gets synced, `AddIP()` panics because `s.dummy` never got set.
* The `hack/kpng-local-up.sh` is out of date using `envsubst` instead of `j2`