### PR TITLE
fix userspace panic while syncing headless svc and dns resolution

### DIFF
--- a/backends/userspacelin/sink.go
+++ b/backends/userspacelin/sink.go
@@ -79,7 +79,7 @@ func (s *Backend) Setup() {
 		utilnet.PortRange{Base: 30000, Size: 2768},
 		time.Duration(15),
 		time.Duration(15),
-		time.Duration(10),
+		time.Millisecond,
 	)
 	if err != nil {
 		log.Fatal("unable to create proxier: ", err)

--- a/backends/userspacelin/userspace_util.go
+++ b/backends/userspacelin/userspace_util.go
@@ -36,7 +36,7 @@ import (
 func ShouldSkipService(service *localnetv1.Service) bool {
 	// if ClusterIP is "None" or empty, skip proxying
 	if !iptables.IsServiceIPSet(service) {
-		klog.V(3).Infof("Skipping service %s in namespace %s due to clusterIP = %q", service.Name, service.Namespace, service.IPs.ClusterIPs.V4[0])
+		klog.V(3).Infof("Skipping service %s in namespace %s due to empty ClusterIPs", service.Name, service.Namespace)
 		return true
 	}
 	// Even if ClusterIP is set, ServiceTypeExternalName services don't get proxied


### PR DESCRIPTION
* Remove log statement referencing a service's ClusterIP(s) while syncing headless services
* Increase UDP connection timeout fixing DNS resolution issues.

Fixes: #335

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>