### PR TITLE
Fix hack README.md run from source

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -26,10 +26,10 @@ However it cant use a vanilla kind recipe because:
 
 # Run from source
 
-To run kpng from source, you can run
+To run kpng from source, you can run (from the source root)
 ```
 docker build -t myname/kpng:ipvs ./
-IMAGE=myname/kpng:ipvs PULL=Never IMAGE=myname:kpng:ipvs BACKEND=ipvs ./kpng-local-up.sh
+IMAGE=myname/kpng:ipvs PULL=Never BACKEND=ipvs ./hack/kpng-local-up.sh
 kind load docker-image myname/kpng:ipvs --name=kpng-proxy
 ```
 


### PR DESCRIPTION
This PR fixes the documentation on the Run from source section which repeats the env var IMAGE with the invalid reference format and also fixes the path to run the `kpng-local-up.sh` script 