### PR TITLE
Fix to run kpng-local-up.sh from source root

### DIFF
--- a/hack/kpng-local-up.sh
+++ b/hack/kpng-local-up.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source ./utils.sh
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "${SCRIPT_DIR}/utils.sh"
 
 # build the kpng image...
 : ${KIND:="kindest/node:v1.22.13@sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959"}


### PR DESCRIPTION
This PR has a small fix to kpng-local-up.sh so it can be run from the source root without issues importing the utils.sh