### PR TITLE
using echo instead of info_message to persist cluster_name

### DIFF
--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -638,7 +638,7 @@ function create_infrastructure_and_run_tests {
     create_cluster "${cluster_name}" "${bin_dir}" "${ip_family}" "${artifacts_directory}" "${ci_mode}"
     wait_until_cluster_is_ready "${cluster_name}" "${bin_dir}" "${ci_mode}"
 
-    info_message "${cluster_name}" > "${e2e_dir}"/clustername
+    echo "${cluster_name}" > "${e2e_dir}"/clustername
 
     if [ "${backend}" != "not-kpng" ] ; then
         install_kpng "${cluster_name}" "${bin_dir}"


### PR DESCRIPTION
### Problem

hack/test_e2e.sh#L641 uses **info_message** function to persist cluster name to file, which adds _ANSI color escape sequences and INFO label_ along with cluster name.

On disk clustername becomes **[ \x1b[34mINFO\x1b[0m ] kpng-e2e-ipv4-iptables** instead of **kpng-e2e-ipv4-iptables**

### Fix
Using **echo** to persist cluster name instead of **info_message**