### PR TITLE
added erase_cluster check before delete_kind_clusters call

### DIFF
--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -874,7 +874,7 @@ function main {
        echo -e "\n+=====================================================================================+"
        echo -e "\t\tDeveloper mode no test run!"
        echo -e "+=====================================================================================+"
-    elif ! ${ci_mode} ; then
+    elif ! ${ci_mode} && ${erase_clusters} ; then
         delete_kind_clusters "${bin_dir}" "${ip_family}" "${backend}" "${suffix}" "${cluster_count}"
     fi
 }


### PR DESCRIPTION
Problem
Setting erase_clusters=false in ./hack/test_e2e.sh erases cluster.

Solution
Adding erase_clusters at the end of **main** function in **test_e2e.sh**

this probably fixes #352 

