### PR TITLE
Moving command_builder to builder module

### DIFF
--- a/cmd/kpng/a2s.go
+++ b/cmd/kpng/a2s.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/kpng/server/pkg/apiwatch"
 	"sigs.k8s.io/kpng/server/proxystore"
 
-	"sigs.k8s.io/kpng/cmd/kpng/storecmds"
+	"sigs.k8s.io/kpng/cmd/kpng/builder"
 )
 
 var (
@@ -54,9 +54,9 @@ func api2storeCmd() *cobra.Command {
 	run := func() {
 		api2storeCmdRun(ctx, store)
 	}
-	api2sCmd.AddCommand(storecmds.ToAPICmd(ctx, store, nil, run))
-	api2sCmd.AddCommand(storecmds.ToFileCmd(ctx, store, nil, run))
-	api2sCmd.AddCommand(storecmds.ToLocalCmd(ctx, store, nil, run))
+	api2sCmd.AddCommand(builder.ToAPICmd(ctx, store, nil, run))
+	api2sCmd.AddCommand(builder.ToFileCmd(ctx, store, nil, run))
+	api2sCmd.AddCommand(builder.ToLocalCmd(ctx, store, nil, run))
 
 	return api2sCmd
 }

--- a/cmd/kpng/builder/command_builder.go
+++ b/cmd/kpng/builder/command_builder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package storecmds
+package builder
 
 import (
 	"context"

--- a/cmd/kpng/f2s.go
+++ b/cmd/kpng/f2s.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kpng/server/jobs/file2store"
 	"sigs.k8s.io/kpng/server/proxystore"
 
-	"sigs.k8s.io/kpng/cmd/kpng/storecmds"
+	"sigs.k8s.io/kpng/cmd/kpng/builder"
 )
 
 // FIXME separate package
@@ -49,9 +49,9 @@ func file2storeCmd() *cobra.Command {
 	run := func() {
 		file2storeCmdRun(ctx, store)
 	}
-	f2sCmd.AddCommand(storecmds.ToAPICmd(ctx, store, nil, run))
-	f2sCmd.AddCommand(storecmds.ToFileCmd(ctx, store, nil, run))
-	f2sCmd.AddCommand(storecmds.ToLocalCmd(ctx, store, nil, run))
+	f2sCmd.AddCommand(builder.ToAPICmd(ctx, store, nil, run))
+	f2sCmd.AddCommand(builder.ToFileCmd(ctx, store, nil, run))
+	f2sCmd.AddCommand(builder.ToLocalCmd(ctx, store, nil, run))
 
 	return f2sCmd
 }

--- a/cmd/kpng/k2s.go
+++ b/cmd/kpng/k2s.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"sigs.k8s.io/kpng/cmd/kpng/storecmds"
+	"sigs.k8s.io/kpng/cmd/kpng/builder"
 
 	"github.com/spf13/cobra"
 
@@ -68,9 +68,9 @@ func kube2storeCmd() *cobra.Command {
 	run := func() {
 		kube2storeCmdRun(ctx, store)
 	}
-	k2sCmd.AddCommand(storecmds.ToAPICmd(ctx, store, kube2storeCmdSetup, run))
-	k2sCmd.AddCommand(storecmds.ToFileCmd(ctx, store, kube2storeCmdSetup, run))
-	k2sCmd.AddCommand(storecmds.ToLocalCmd(ctx, store, kube2storeCmdSetup, run))
+	k2sCmd.AddCommand(builder.ToAPICmd(ctx, store, kube2storeCmdSetup, run))
+	k2sCmd.AddCommand(builder.ToFileCmd(ctx, store, kube2storeCmdSetup, run))
+	k2sCmd.AddCommand(builder.ToLocalCmd(ctx, store, kube2storeCmdSetup, run))
 
 	return k2sCmd
 }

--- a/cmd/kpng/local.go
+++ b/cmd/kpng/local.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kpng/client/localsink"
-	"sigs.k8s.io/kpng/cmd/kpng/storecmds"
+	"sigs.k8s.io/kpng/cmd/kpng/builder"
 	"sigs.k8s.io/kpng/server/jobs/api2local"
 )
 
@@ -36,7 +36,7 @@ func local2sinkCmd() *cobra.Command {
 	job := api2local.New(nil)
 	job.BindFlags(flags)
 
-	cmd.AddCommand(storecmds.LocalCmds(func(sink localsink.Sink) (err error) {
+	cmd.AddCommand(builder.LocalCmds(func(sink localsink.Sink) (err error) {
 		ctx := setupGlobal()
 		job.Sink = sink
 		job.Run(ctx)

--- a/cmd/kpng/main.go
+++ b/cmd/kpng/main.go
@@ -27,6 +27,9 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kpng/server/pkg/metrics"
 
+	// import existent backends quietly
+	_ "sigs.k8s.io/kpng/cmd/kpng/storecmds"
+
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/kpng/server/pkg/proxy"


### PR DESCRIPTION
Moving `command_builder` to a `builder` module in order to be able to use `ToLocalCmd` or `LocalCmds` on external projects.
https://github.com/kubernetes-sigs/windows-service-proxy/pull/1

Adding the backends Register in the main.go instead, so the modules listed on `storecmds` are NOT imported automatically when `builder` is used.
