### PR TITLE
fix kpng version command and standardize build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ run apk add --update --no-cache \
 arg GOPROXY
 arg GONOSUMDB
 
+arg RELEASE
+arg GIT_REPO_URL
+arg GIT_COMMIT_HASH
+
 # cache dependencies, they don't change as much as the code
 copy --from=gomods /src/ /src/
 
@@ -24,7 +28,7 @@ run go mod download
 
 add . ./
 #run for f in $(find -name go.mod); do d=$(dirname $f); echo "testing in $d"; ( cd $d && go test ./... ); done
-run go install -trimpath -buildvcs=false ./cmd/...
+run go install -trimpath -buildvcs=false -ldflags "-X main.RELEASE=$RELEASE -X main.REPO=$GIT_REPO_URL -X main.COMMIT=$GIT_COMMIT_HASH" ./cmd/...
 
 # the real image
 from alpine:3.16

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,25 @@
 
 all: help
 
-# kpng build info
-VERSION=$(shell git describe --tags --always --long)
-LDFLAGS="-X main.version=$(VERSION)"
-ARCH="amd64"
-BUILD_DIR="kpng-bin"
-export PLATFORM=""
+# Host info
+HOST_ARCH = $(shell which go >/dev/null 2>&1 && go env GOARCH)
+export ARCH ?= $(HOST_ARCH)
+ifeq ($(ARCH),)
+    $(error mandatory variable ARCH is empty, either set it when calling the command or make sure 'go env GOARCH' works)
+endif
+BUILD_DIR=kpng-bin
+PLATFORM=""
+
+# Build info
+RELEASE ?= UNKNOWN
+GIT_REPO_URL ?= $(shell git config --get remote.origin.url)
+GIT_COMMIT_HASH ?= git-$(shell git rev-parse --short HEAD)
+LDFLAGS="-X main.RELEASE=$(RELEASE) -X main.REPO=$(GIT_REPO_URL) -X main.COMMIT=$(GIT_COMMIT_HASH)"
+
+# Image info
+CONTAINER_ENGINE ?= docker
+CONTAINER_FILE ?= $(shell echo "${PWD}/Dockerfile")
+KPNG_IMAGE_TAG_NAME ?= kpng:test
 
 # Auto Generate help from: https://gist.github.com/prwhite/8168133
 # COLORS
@@ -123,17 +136,27 @@ windows:
 	@$(MAKE) -e build
 
 build:
-	@mkdir -p $(BUILD_DIR)/$(PLATFORM)/$(VERSION)
+	@mkdir -p $(BUILD_DIR)/$(ARCH)
 	@cd cmd && \
 		env GOOS=$(PLATFORM) \
 		GOARCH=$(ARCH) \
 		go build \
 		-trimpath \
-		-o ../$(BUILD_DIR)/$(PLATFORM)/$(VERSION) \
+		-o ../$(BUILD_DIR)/$(ARCH) \
 		-v \
 		-ldflags=$(LDFLAGS) \
 		./...
-	@echo "\tkpng $(YELLOW)$(PLATFORM)$(RESET) binaries available in: $(GREEN)$(BUILD_DIR)/$(PLATFORM)/$(VERSION)$(RESET)\n"
+	@echo "\tkpng $(YELLOW)$(ARCH)$(RESET) binaries available in: $(GREEN)$(BUILD_DIR)/$(ARCH)$(RESET)\n"
+
+image:
+	$(CONTAINER_ENGINE) build \
+	$(QUIET_MODE) \
+	-t $(KPNG_IMAGE_TAG_NAME) \
+	-f $(CONTAINER_FILE) \
+	--build-arg RELEASE=$(RELEASE) \
+	--build-arg GIT_REPO_URL=$(GIT_REPO_URL) \
+	--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) \
+	.
 
 ## Create Kind cluster for Tilt. It requires backend(b) and ipfamily (i) as args. eg: make tilt-setup i=ipv4 b=nft
 tilt-setup:

--- a/cmd/kpng/main.go
+++ b/cmd/kpng/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
+	_ "fmt"
 	"os"
 	"runtime/pprof"
 
@@ -35,8 +35,6 @@ import (
 var (
 	cpuprofile    = flag.String("cpuprofile", "", "write cpu profile to file")
 	exportMetrics = flag.String("exportMetrics", "", "start metrics server on the specified IP:PORT")
-
-	version = "(unknown)"
 )
 
 // main starts the kpng program by running the command sent by the user.  This is the entry point to kpng!
@@ -95,14 +93,4 @@ func setupGlobal() (ctx context.Context) {
 	}
 
 	return
-}
-
-func versionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "version",
-		Short: "print the version and quit",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
-		},
-	}
 }

--- a/cmd/kpng/main.go
+++ b/cmd/kpng/main.go
@@ -19,7 +19,7 @@ package main
 import (
 	"context"
 	"flag"
-	_ "fmt"
+	"fmt"
 	"os"
 	"runtime/pprof"
 

--- a/cmd/kpng/version.go
+++ b/cmd/kpng/version.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// RELEASE returns the release version
+	RELEASE = "UNKNOWN"
+	// REPO returns the git repository URL
+	REPO = "UNKNOWN"
+	// COMMIT returns the short sha from git
+	COMMIT = "UNKNOWN"
+)
+
+// versionCmd is responsible for printing relevant information regarding KPNG's version
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print the version and quit",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(kpngVersion())
+		},
+	}
+}
+
+// kpngVersion returns information about the version.
+func kpngVersion() string {
+	return fmt.Sprintf(`-------------------------------------------------------------------------------
+Kubernetes Proxy NG
+  Commit:        %v
+  Release:       %v
+  Repository:    %v
+-------------------------------------------------------------------------------
+`, COMMIT, RELEASE, REPO)
+}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -37,6 +37,11 @@ CLUSTER_NAME="kpng-proxy"
 K8S_VERSION="v1.25.3"
 OS=$(uname| tr '[:upper:]' '[:lower:]')
 
+GIT_COMMIT_HASH=$(git describe --tags --always --long)
+GIT_REPO_URL=$(git config --get remote.origin.url)
+# TODO: Create release tag
+RELEASE=UNKNOWN
+
 function add_to_path {
     ###########################################################################
     # Description:                                                            #

--- a/hack/go-build
+++ b/hack/go-build
@@ -1,3 +1,0 @@
-set -ex
-test -n "$VERSION" || VERSION=$(git describe --dirty --tags)
-CGO_ENABLED=1 go build -trimpath -o dist -ldflags "-X main.version=$VERSION" $(hack/go-list-local-mods)

--- a/hack/kpng-local-up.sh
+++ b/hack/kpng-local-up.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${SCRIPT_DIR}/utils.sh"
 source "${SCRIPT_DIR}/common.sh"
 
-: ${IMAGE:="test/kpng:latest"}
+: ${KPNG_IMAGE_TAG_NAME:="kpng:test"}
 : ${PULL:="IfNotPresent"}
 : ${BACKEND:="nft"}
 : ${CONFIG_MAP_NAME:=kpng}
@@ -30,20 +30,21 @@ source "${SCRIPT_DIR}/common.sh"
 : ${SERVER_ARGS:="['kube','--kubeconfig=/var/lib/kpng/kubeconfig.conf', '--exportMetrics=0.0.0.0:9099', 'to-api']"}
 : ${DEPLOYMENT_MODEL:="split-process-per-node"}
 
-echo -n "this will deploy kpng with docker image $IMAGE, pull policy '$PULL' and the '$BACKEND' backend. Press enter to confirm, C-c to cancel"
+echo -n "this will deploy kpng with docker image $KPNG_IMAGE_TAG_NAME, pull policy '$PULL' and the '$BACKEND' backend. Press enter to confirm, C-c to cancel"
 read
 
 # build the kpng image...
 function build_kpng {
     cd ../
 
-    if docker build -t $IMAGE ./ ; then
-	echo "passed build"
+    export
+    if make image ; then
+      echo "passed build"
     else
 	echo "failed build"
         exit 123
     fi
-    docker push $IMAGE
+    docker push $KPNG_IMAGE_TAG_NAME
     cd hack/
 }
 
@@ -60,7 +61,7 @@ function install_k8s {
 function install_kpng {
     echo "Applying template"
     # Setting vars for generate the kpng deployment based on template
-    export kpng_image="${IMAGE}" 
+    export kpng_image="${KPNG_IMAGE_TAG_NAME}"
     export image_pull_policy="${PULL}" 
     export backend="${BACKEND}" 
     export config_map_name="${CONFIG_MAP_NAME}" 
@@ -73,7 +74,7 @@ function install_kpng {
     go run kpng-ds-yaml-gen.go ./kpng-deployment-ds-template.txt ./kpng-deployment-ds.yaml
     if_error_exit "error generating kpng deployment YAML"
 
-    kind load docker-image $IMAGE --name kpng-proxy
+    kind load docker-image $KPNG_IMAGE_TAG_NAME --name kpng-proxy
 
     # todo(jayunit100) support antrea as a secondary CNI option to test
 

--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -102,15 +102,13 @@ function container_build {
     [ -f "${CONTAINER_FILE}" ]
     if_error_exit "cannot find ${CONTAINER_FILE}"
 
-    CMD_BUILD_IMAGE=("${CONTAINER_ENGINE} build ${QUIET_MODE} -t ${KPNG_IMAGE_TAG_NAME} -f ${CONTAINER_FILE} .")
     pushd "${0%/*}/.." > /dev/null || exit
         if [ -z "${QUIET_MODE}" ]; then
-            ${CMD_BUILD_IMAGE}
+            make image
         else
-            ${CMD_BUILD_IMAGE} &> /dev/null
-
+            make image &> /dev/null
         fi
-        if_error_exit "Failed to build kpng, command was: ${CMD_BUILD_IMAGE}"
+        if_error_exit "Failed to build kpng, command was: make image"
     popd > /dev/null || exit
 
     pass_message "Image build and tag ${KPNG_IMAGE_TAG_NAME} is set."

--- a/hack/tilt/deploy.sh
+++ b/hack/tilt/deploy.sh
@@ -17,14 +17,14 @@
 TILT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 SCRIPT_DIR=$(dirname $TILT_DIR)
 SRC_DIR=$(dirname $SCRIPT_DIR)
-BIN_DIR=$(dirname $SCRIPT_DIR)/temp/tilt/bin 
+BIN_DIR=$(dirname $SCRIPT_DIR)/temp/tilt/bin
+export KPNG_IMAGE_TAG_NAME="kpng:latest"
 
 source ${SCRIPT_DIR}/utils.sh
-source ${SCRIPT_DIR}/common.sh 
+source ${SCRIPT_DIR}/common.sh
 
-KPNG_IMAGE="kpng"
 function build_kpng_and_load_image {
-  if docker build -t $KPNG_IMAGE:latest $SRC_DIR/ ; then
+  if (cd $SRC_DIR && make image) ; then
 	  echo "passed build"
   else
 	  echo "failed build"


### PR DESCRIPTION
fixes #228 

The problem here likely stems from the fact that, currently, [there are too many ways to build and deploy KPNG](https://kubernetes.slack.com/archives/C02GA1RSCLR/p1673117536594379). None of them were passing the commit SHA to go build/install.

This PR:
- fixes the version command for `make tilt-up`, `make build`,  `kpng-local-up.sh`, and `test_e2e.sh`;
- makes all the tools above build `kpng` with the same command (`make image`);