### PR TITLE
add security pipeline that scans with gosec and govulncheck

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,60 @@
+name: Security
+
+on:
+  pull_request:
+    branches:
+      - "*"
+    paths-ignore:
+      - 'doc/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'doc/**'
+
+env:
+  GO_VERSION: "1.19"
+
+jobs:
+  gosec:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@1af1d5bb49259b62e45c505db397dd2ada5d74f8 # v2.14.0
+        with:
+          # Ignoring:
+          # G104: Errors not checked
+          # G306: Expect WriteFile permissions to be 0600 or less
+          # G307: Deferring unsafe method "Close"
+          args: -exclude=G104,G306,G307 -tests=false -exclude-dir=doc/ -no-fail -fmt sarif -out gosec-results.sarif  ./...
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: gosec-results.sarif
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Scan for Vulnerabilities in Code
+        uses: Templum/govulncheck-action@v0.0.8
+        with:
+          package: cmd/...
+          skip-upload: true
+          fail-on-vuln: false
+          vulncheck-version: latest
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: govulncheck-report.sarif


### PR DESCRIPTION
fixes #424 

This PR introduces a simple security pipeline.
It uses [gosec](https://github.com/securego/gosec) and [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) (static code analysis tools) to scan for common/known vulnerabilities.

Both tools upload SARIF reports that are later used by the [Github's code scanning API](https://docs.github.com/en/rest/code-scanning?apiVersion=2022-11-28).

Signed-off-by: jaehnri <joao.henri.cr@gmail.com>