### PR TITLE
Update e2e_tests.yaml: add -S flag to call of test_e2e.sh

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -64,7 +64,7 @@ jobs:
         fi 
 
     - name: run e2e tests
-      run: ./hack/test_e2e.sh -i ${{ env.IP_FAMILY }} -b ${{ env.BACKEND }} -c -n 1
+      run: ./hack/test_e2e.sh -i ${{ env.IP_FAMILY }} -b ${{ env.BACKEND }} -c -n 1 -S
 
     - name: Export logs
       if: always()


### PR DESCRIPTION
Tests now use -S flag when calling test_e2e.sh. This flag will ensure that the extra test skip lists are used