### PR TITLE
[WIP] #430 make e2e csv full report all backends target

### DIFF
--- a/hack/.gitignore
+++ b/hack/.gitignore
@@ -2,3 +2,4 @@ kpng-deployment-ds.yaml
 /sonobuoy
 /temp
 /_artifacts
+/temp_go

--- a/hack/common.go
+++ b/hack/common.go
@@ -1,0 +1,1 @@
+// This file will contain functions that will be share by, possible, many other go programs.

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -189,9 +189,54 @@ func setup_kubectl(install_directory, k8s_version, operating_system string) {
 		_ = cmd.Run()
 		cmd = exec.Command("sudo", "chown", "root.root", install_directory + "/kubectl")
 		_ = cmd.Run()
+
+		fmt.Println("The Kubectl tool is set.")
 	}
 
 	
+}
+
+func setup_ginkgo(install_directory, k8s_version, operating_system string) {
+    ///////////////////////////////////////////////////////////////////////////
+	// Description:
+    // setup ginkgo and e2e.test
+    //
+    // # Arguments:
+    //   arg1: binary directory, path to where ginko will be installed
+    //   arg2: Kubernetes version
+    //  arg3: OS, name of the operating system
+	/////////////////////////////////////////////////////////////////////////// 
+
+	//Create temp directory
+	tmp_dir, err := os.MkdirTemp(".", "ginkgo_setup_")  //I think this should only happen in case ginkgo and e2e.test are not installed. Fix later
+	if_error_exit(err)
+	defer os.RemoveAll(tmp_dir) //Clean up
+
+	_, ginkgo_exist := os.Stat(install_directory + "/ginkgo")
+	_, e2e_test_exist := os.Stat(install_directory + "/e2e.test")
+
+	if os.IsNotExist(ginkgo_exist) || os.IsNotExist(e2e_test_exist) {
+		fmt.Println("Downloading ginkgo and e2e.test ...")
+		url := "https://dl.k8s.io/" + k8s_version + "/kubernetes-test-" + operating_system + "-amd64.tar.gz"
+		out_file := tmp_dir + "/kubernetes-test-" + operating_system + "-amd64.tar.gz"
+
+		cmd := exec.Command("curl", "-L", url, "-o", out_file)
+		err = cmd.Run()
+		if_error_exit(err)
+
+		tar_file := tmp_dir + "/kubernetes-test-" + operating_system + "-amd64.tar.gz" 
+		cmd_string := "tar xvzf " + tar_file + " --directory " + install_directory + " --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test &> /dev/null"
+		cmd = exec.Command("bash", "-c", cmd_string)
+		err = cmd.Run()
+		if_error_exit(err)
+
+		fmt.Println("The tools ginko and e2e.test have been set up.")
+
+	} else {
+		fmt.Println("The tools ginko and e2e.test have already been set up.")
+	}
+
+
 }
 
 func install_binaries(bin_directory, k8s_version, operating_system, base_dir_path string, ) {
@@ -216,7 +261,8 @@ func install_binaries(bin_directory, k8s_version, operating_system, base_dir_pat
 	add_to_path(bin_directory) 
 
 	setup_kind(bin_directory, operating_system)
-	setup_kubectl(bin_directory, k8s_version, operating_system )
+	setup_kubectl(bin_directory, k8s_version, operating_system)
+	setup_ginkgo(bin_directory, k8s_version, operating_system)
 }
 
 

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -55,12 +55,17 @@ func set_host_network_settings(ip_family string) {
 	//
 	// Arguments: 
 	//	arg1: ip_family
-
-
+	///////////////////////////////////////////////////////////////////////
+	set_sysctl("net.ipv4.ip_forward", 1)
+	if ip_family = "ipv6" {
+		//TODO 
+		fmt.Println("TODO :-)")
+	}	
 }
 
+
 func main() {
-	fmt.Println("Verify Host Networking Settings")
-	set_sysctl("net.ipv4.ip_forward", 1)
+	fmt.Println("Ola :-)")
+	
 
 }

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -13,35 +13,35 @@ import (
 ) 
 
 const (
-	KIND_VERSION="v0.17.0"
-	K8S_VERSION="v1.25.3"
-	KPNG_IMAGE_TAG_NAME="kpng:test_270323_0904" 
-	CLUSTER_CIDR_V4="10.1.0.0/16"
-	SERVICE_CLUSTER_IP_RANGE_V4="10.2.0.0/16"
-	KINDEST_NODE_IMAGE="docker.io/kindest/node"
-	E2E_K8S_VERSION="v1.25.3"
-	KUBECONFIG_TESTS="kubeconfig_tests.conf"
+	KindVersion="v0.17.0"
+	KubernetesVersion="v1.25.3"
+	KpngImageTagName="kpng:test_270323_0904" 
+	ClusterCidrV4="10.1.0.0/16"
+	ServiceClusterIpRangeV4="10.2.0.0/16"
+	KindestNodeImage="docker.io/kindest/node"
+	E2eK8sVersion="v1.25.3"
+	KubeconfigTests="kubeconfig_tests.conf"
 )
 // System data
 const (
-	NAMESPACE="kube-system"
-	SERVICE_ACCOUNT_NAME="kpng"
-	CLUSTER_ROLE_BINDING_NAME="kpng"
-	CLUSTER_ROLE_NAME="system:node-proxier"
-	CONFIG_MAP_NAME="kpng"
+	Namespace="kube-system"
+	ServiceAccountName="kpng"
+	ClusterRoleBindingName="kpng"
+	ClusterRoleName="system:node-proxier"
+	ConfigMapName="kpng"
 
-	KPNG_SERVER_ADDRESS="unix:///k8s/proxy.sock"
-	KPNG_DEBUG_LEVEL="4"
+	KpngServerAddress="unix:///k8s/proxy.sock"
+	KpngDebugLevel="4"
 )
 // Ginkgo
 const (
-	GINKGO_SKIP_TESTS="machinery|Feature|Federation|PerformanceDNS|Disruptive|Serial|LoadBalancer|KubeProxy|GCE|Netpol|NetworkPolicy"
-	GINKGO_FOCUS="\\[Conformance\\]|\\[sig-network\\]"
-	GINKGO_NUMBER_OF_NODES=25
-	GINKGO_PROVIDER="local"
-	GINKGO_DUMP_LOGS_ON_FAILURE=false
-	GINKGO_REPORT_DIR="artifacts/reports"
-	GINKGO_DISABLE_LOG_DUMP=true
+	GinkgoSkipTests="machinery|Feature|Federation|PerformanceDNS|Disruptive|Serial|LoadBalancer|KubeProxy|GCE|Netpol|NetworkPolicy"
+	GinkgoFocus="\\[Conformance\\]|\\[sig-network\\]"
+	GinkgoNumberOfNodes=25
+	GinkgoProvider="local"
+	GinkgoDumpLogsOnFailure=false
+	GinkgoReportDir="artifacts/reports"
+	GinkgoDisableLogDump=true
 )
 
 var kpng_dir, CONTAINER_ENGINE string
@@ -174,7 +174,7 @@ func setup_kind(install_directory, operating_system string) {
 		if_error_exit(err)
 		defer os.Remove(tmp_file.Name()) // Clean up. QUESTION: As we will end up moving the temp file, is this necessary? 
 	
-		url := "https://kind.sigs.k8s.io/dl/" + KIND_VERSION + "/kind-" + operating_system + "-amd64"
+		url := "https://kind.sigs.k8s.io/dl/" + KindVersion + "/kind-" + operating_system + "-amd64"
 		fmt.Printf("Temp filename: %s\n", tmp_file.Name())
 		cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())	
 		err = cmd.Run()
@@ -346,13 +346,13 @@ func container_build(CONTAINER_FILE string, ci_mode bool) {
 	}
 
 	if QUIET_MODE == "" {
-		cmd := exec.Command(CONTAINER_ENGINE, "build", "-t", KPNG_IMAGE_TAG_NAME, "-f", CONTAINER_FILE, ".")
+		cmd := exec.Command(CONTAINER_ENGINE, "build", "-t", KpngImageTagName, "-f", CONTAINER_FILE, ".")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		cmd := exec.Command(CONTAINER_ENGINE, "build", QUIET_MODE, "-t", KPNG_IMAGE_TAG_NAME, "-f", CONTAINER_FILE, ".")
+		cmd := exec.Command(CONTAINER_ENGINE, "build", QUIET_MODE, "-t", KpngImageTagName, "-f", CONTAINER_FILE, ".")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal(err)
@@ -363,7 +363,7 @@ func container_build(CONTAINER_FILE string, ci_mode bool) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Image build and tag %s is set.\n", KPNG_IMAGE_TAG_NAME)
+	fmt.Printf("Image build and tag %s is set.\n", KpngImageTagName)
 }
 
 // set_e2e_dir set E2E directory.
@@ -478,8 +478,8 @@ nodes:
 	
 	switch ip_family {
 	case "ipv4":
-		CLUSTER_CIDR = CLUSTER_CIDR_V4
-        SERVICE_CLUSTER_IP_RANGE = SERVICE_CLUSTER_IP_RANGE_V4
+		CLUSTER_CIDR = ClusterCidrV4
+        SERVICE_CLUSTER_IP_RANGE = ServiceClusterIpRangeV4
 	}
 
 	fmt.Printf("Preparing to setup %s cluster ...\n", cluster_name)
@@ -508,7 +508,7 @@ nodes:
 	cmd_string_set := []string {
 		kind + " create cluster ",
 		"--name " + cluster_name,
-		" --image " + KINDEST_NODE_IMAGE + ":" + E2E_K8S_VERSION,
+		" --image " + KindestNodeImage + ":" + E2eK8sVersion,
 		" --retain",
 		" --wait=1m ",
 		kind_log_level,
@@ -550,12 +550,12 @@ nodes:
 		log.Fatalf("Failed to create the file kubeconfig.conf.\n", err)
 	}
 
-	// Generate the file KUBECONFIG_TESTS on the artifacts directory
-	cmd_string = kind + " get kubeconfig --name " + cluster_name +" > " + artifacts_directory + "/" + KUBECONFIG_TESTS
+	// Generate the file KubeconfigTests on the artifacts directory
+	cmd_string = kind + " get kubeconfig --name " + cluster_name +" > " + artifacts_directory + "/" + KubeconfigTests
 	cmd = exec.Command("bash", "-c", cmd_string)
 	err = cmd.Run()
 	if err != nil {
-		log.Fatalf("Failed to create the file KUBECONFIG_TESTS.\n", err)
+		log.Fatalf("Failed to create the file KubeconfigTests.\n", err)
 	}
 
 	fmt.Printf("Cluster %s is created.\n", cluster_name)
@@ -578,7 +578,7 @@ func wait_until_cluster_is_ready(cluster_name, bin_dir string, ci_mode bool) {
 		log.Fatal(err)
 	}
 
-	cmd_string := "kubectl --context " + k8s_context + " wait --for=condition=ready pods --namespace=" + NAMESPACE + " --selector k8s-app=kube-dns 1> /dev/null"
+	cmd_string := "kubectl --context " + k8s_context + " wait --for=condition=ready pods --namespace=" + Namespace + " --selector k8s-app=kube-dns 1> /dev/null"
 	cmd := exec.Command("bash", "-c", cmd_string)
 	err = cmd.Run()
 	if err != nil {
@@ -627,7 +627,7 @@ func install_kpng(cluster_name, bin_dir string) {
 	}
 
 	// Remove existing kube-proxy
-	cmd := exec.Command(kubectl, "--context", k8s_context, "delete", "--namespace", NAMESPACE, "daemonset.apps/kube-proxy")
+	cmd := exec.Command(kubectl, "--context", k8s_context, "delete", "--namespace", Namespace, "daemonset.apps/kube-proxy")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Cannot delete delete daemonset.apps kube-proxy\n", err)
@@ -636,53 +636,53 @@ func install_kpng(cluster_name, bin_dir string) {
 
 	// Load kpng container image
 	// Preload kpng image 
-	cmd = exec.Command(kind, "load", "docker-image", KPNG_IMAGE_TAG_NAME, "--name", cluster_name)
+	cmd = exec.Command(kind, "load", "docker-image", KpngImageTagName, "--name", cluster_name)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error loading image to kind.\n", err)
 	}
-	fmt.Println("Loaded " + KPNG_IMAGE_TAG_NAME + " container image.")
+	fmt.Println("Loaded " + KpngImageTagName + " container image.")
 
 	// Create service account, clusterbinding and configmap for kpng
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "serviceaccount", "--namespace", NAMESPACE, SERVICE_ACCOUNT_NAME)
+	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "serviceaccount", "--namespace", Namespace, ServiceAccountName)
 	err = cmd.Run()
 	if err != nil {
-		log.Fatalf("Error creating serviceaccount %s.\n", SERVICE_ACCOUNT_NAME, err)
+		log.Fatalf("Error creating serviceaccount %s.\n", ServiceAccountName, err)
 	}
-	fmt.Println("Created service account", SERVICE_ACCOUNT_NAME)
+	fmt.Println("Created service account", ServiceAccountName)
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "clusterrolebinding", CLUSTER_ROLE_BINDING_NAME, "--clusterrole", CLUSTER_ROLE_NAME, "--serviceaccount", NAMESPACE + ":"+ SERVICE_ACCOUNT_NAME)
+	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "clusterrolebinding", ClusterRoleBindingName, "--clusterrole", ClusterRoleName, "--serviceaccount", Namespace + ":"+ ServiceAccountName)
 	err = cmd.Run()
 	if err != nil {
-		log.Fatalf("Error creating clusterrolebinding %s.\n", CLUSTER_ROLE_BINDING_NAME, err)
+		log.Fatalf("Error creating clusterrolebinding %s.\n", ClusterRoleBindingName, err)
 	}
-	fmt.Println("Created clusterrolebinding", CLUSTER_ROLE_BINDING_NAME)
+	fmt.Println("Created clusterrolebinding", ClusterRoleBindingName)
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "configmap", CONFIG_MAP_NAME, "--namespace", NAMESPACE, "--from-file", artifacts_directory + "/kubeconfig.conf")
+	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "configmap", ConfigMapName, "--namespace", Namespace, "--from-file", artifacts_directory + "/kubeconfig.conf")
 	err = cmd.Run()
 	if err != nil {
-		log.Fatalf("Error creating configmap", CONFIG_MAP_NAME)
+		log.Fatalf("Error creating configmap", ConfigMapName)
 	}
-	fmt.Println("Created configmap", CONFIG_MAP_NAME)
+	fmt.Println("Created configmap", ConfigMapName)
 
 	// Deploy kpng from the template generated
 	E2E_SERVER_ARGS := "'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-api', '--listen=unix:///k8s/proxy.sock'"
-    E2E_BACKEND_ARGS := "'local', '--api=" + KPNG_SERVER_ADDRESS + "', 'to-" + E2E_BACKEND + "', '--v=" + KPNG_DEBUG_LEVEL + "'"
+    E2E_BACKEND_ARGS := "'local', '--api=" + KpngServerAddress + "', 'to-" + E2E_BACKEND + "', '--v=" + KpngDebugLevel + "'"
 
 	if E2E_DEPLOYMENT_MODEL == "single-process-per-node" {
-		E2E_BACKEND_ARGS="'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-local', 'to-" + E2E_BACKEND + "', '--v=" + KPNG_DEBUG_LEVEL + "'"
+		E2E_BACKEND_ARGS="'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-local', 'to-" + E2E_BACKEND + "', '--v=" + KpngDebugLevel + "'"
 	} 
 
 	E2E_SERVER_ARGS = "[" + E2E_SERVER_ARGS + "]"
 	E2E_BACKEND_ARGS = "[" + E2E_BACKEND_ARGS + "]"
 
 	// Setting vars for generate the kpng deployment based on template
-	_ = os.Setenv("kpng_image", KPNG_IMAGE_TAG_NAME) 
+	_ = os.Setenv("kpng_image", KpngImageTagName) 
     _ = os.Setenv("image_pull_policy", "IfNotPresent") 
     _ = os.Setenv("backend", E2E_BACKEND) 
-    _ = os.Setenv("config_map_name", CONFIG_MAP_NAME) 
-    _ = os.Setenv("service_account_name", SERVICE_ACCOUNT_NAME) 
-    _ = os.Setenv("namespace", NAMESPACE) 
+    _ = os.Setenv("config_map_name", ConfigMapName) 
+    _ = os.Setenv("service_account_name", ServiceAccountName) 
+    _ = os.Setenv("namespace", Namespace) 
     _ = os.Setenv("e2e_backend_args", E2E_BACKEND_ARGS)
     _ = os.Setenv("deployment_model", E2E_DEPLOYMENT_MODEL)
     _ = os.Setenv("e2e_server_args", E2E_SERVER_ARGS)
@@ -704,7 +704,7 @@ func install_kpng(cluster_name, bin_dir string) {
 		log.Fatalf("Error creating kpng deployment \n", err)
 	}
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "--namespace", NAMESPACE, "rollout", "status", "daemonset", "kpng", "-w", "--request-timeout", "3m")	
+	cmd = exec.Command(kubectl, "--context", k8s_context, "--namespace", Namespace, "rollout", "status", "daemonset", "kpng", "-w", "--request-timeout", "3m")	
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Timeout waiting kpng rollout\n", err)
@@ -721,7 +721,7 @@ func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, b
 	ginkgo := bin_dir + "/ginkgo"
 	e2e_test := bin_dir + "/e2e.test"
 
-	_, err := os.Stat(artifacts_directory + "/" + KUBECONFIG_TESTS)
+	_, err := os.Stat(artifacts_directory + "/" + KubeconfigTests)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
@@ -739,12 +739,12 @@ func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, b
 	}
 
 	// Ginkgo regexes
-	ginkgo_skip := GINKGO_SKIP_TESTS
+	ginkgo_skip := GinkgoSkipTests
 	ginkgo_focus := ""
-	if strings.TrimSpace(GINKGO_FOCUS) == "" {
+	if strings.TrimSpace(GinkgoFocus) == "" {
 		ginkgo_focus = "\\[Conformance\\]"
 	} else {
-		ginkgo_focus = GINKGO_FOCUS
+		ginkgo_focus = GinkgoFocus
 	}
 	
 	var skip_set_name,  skip_set_ref string
@@ -765,9 +765,9 @@ func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, b
 	_ = os.Setenv("KUBE_CONTAINER_RUNTIME_ENDPOINT", "unix:///run/containerd/containerd.sock")
 	_ = os.Setenv("KUBE_CONTAINER_RUNTIME_NAME", "containerd")
 
-	cmd := exec.Command(ginkgo, "--nodes", strconv.Itoa(GINKGO_NUMBER_OF_NODES), "--focus", ginkgo_focus, "--skip", ginkgo_skip, e2e_test, 
-		"--kubeconfig", artifacts_directory + "/" + KUBECONFIG_TESTS, "--provider", GINKGO_PROVIDER, "--dump-logs-on-failure", strconv.FormatBool(GINKGO_DUMP_LOGS_ON_FAILURE), 
-	 	"--report-dir", GINKGO_REPORT_DIR, "--disable-log-dump", strconv.FormatBool(GINKGO_DISABLE_LOG_DUMP))
+	cmd := exec.Command(ginkgo, "--nodes", strconv.Itoa(GinkgoNumberOfNodes), "--focus", ginkgo_focus, "--skip", ginkgo_skip, e2e_test, 
+		"--kubeconfig", artifacts_directory + "/" + KubeconfigTests, "--provider", GinkgoProvider, "--dump-logs-on-failure", strconv.FormatBool(GinkgoDumpLogsOnFailure), 
+	 	"--report-dir", GinkgoReportDir, "--disable-log-dump", strconv.FormatBool(GinkgoDisableLogDump))
 	err = cmd.Run()
 	
 	if err != nil {
@@ -815,11 +815,11 @@ func create_imfrastructure_and_run_tests(e2e_dir, ip_family, backend, bin_dir, s
 	if backend != "not-kpng" {
 		install_kpng(cluster_name, bin_dir)
 	}
-
+/*
 	if developer_mode == true {
 		run_tests(e2e_dir, bin_dir, false, ip_family, backend, include_specific_failed_tests)
 	}
-
+*/
 }
 
 func main() {
@@ -874,7 +874,7 @@ func main() {
 	if_error_exit(err)
 	dockerfile = strings.TrimSpace(buffer.String()) + "/Dockerfile"
 
-	install_binaries(bin_dir, K8S_VERSION, OS, base_dir)
+	install_binaries(bin_dir, KubernetesVersion, OS, base_dir)
 	prepare_container(dockerfile, ci_mode)
 
 	tmp_suffix := ""

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -44,20 +44,20 @@ const (
 	GinkgoDisableLogDump=true
 )
 
-var kpng_dir, CONTAINER_ENGINE string
+var kpngDir, containerEngine string
 
 // if_error_exit validate if previous command failed and show an error msg (if provided).
 //
 // If an error message is not provided, it will just exit.
-func if_error_exit(error_msg error) {
-	if error_msg != nil {
-		log.Fatal(error_msg)
+func if_error_exit(errorMsg error) {
+	if errorMsg != nil {
+		log.Fatal(errorMsg)
 	}
 } 
 
-// command_exist check if a binary(cmd_test) exists. It returns True or False 
-func command_exist(cmd_test string) bool {
-	cmd_script := "command -v " + cmd_test + " > /dev/null 2>&1"
+// command_exist check if a binary(cmdTest) exists. It returns True or False 
+func command_exist(cmdTest string) bool {
+	cmd_script := "command -v " + cmdTest + " > /dev/null 2>&1"
 	cmd := exec.Command("bash", "-c", cmd_script)
 	err := cmd.Run()
 	
@@ -127,9 +127,9 @@ func set_sysctl(attribute string, value int) {
 }
 
 // set_host_network_settings prepare hosts network settings 
-func set_host_network_settings(ip_family string) {
+func set_host_network_settings(ipFamily string) {
 	set_sysctl("net.ipv4.ip_forward", 1)
-	if ip_family == "ipv6" {
+	if ipFamily == "ipv6" {
 		//TODO 
 		fmt.Println("TODO :-)")
 	}	
@@ -152,18 +152,18 @@ func verify_sysctl_setting(attribute string, value int) {
 }
 
 // verify_host_network_settings verify hosts network settings                                           
-func verify_host_network_settings(ip_family string) {
+func verify_host_network_settings(ipFamily string) {
 	verify_sysctl_setting("net.ipv4.ip_forward", 1)
 } 
 
-// setup_kind setup kind in the install_directory if not available in the operating_system.
-func setup_kind(install_directory, operating_system string) {
-	_, err := os.Stat(install_directory)
+// setup_kind setup kind in the installDirectory if not available in the operatingSystem.
+func setup_kind(installDirectory, operatingSystem string) {
+	_, err := os.Stat(installDirectory)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
 
-	_, err = os.Stat(install_directory + "/kind")
+	_, err = os.Stat(installDirectory + "/kind")
 	if err == nil {
 		fmt.Println("The kind tool is already set in your system.")
 	} else if err != nil && os.IsNotExist(err) {
@@ -174,31 +174,31 @@ func setup_kind(install_directory, operating_system string) {
 		if_error_exit(err)
 		defer os.Remove(tmp_file.Name()) // Clean up. QUESTION: As we will end up moving the temp file, is this necessary? 
 	
-		url := "https://kind.sigs.k8s.io/dl/" + KindVersion + "/kind-" + operating_system + "-amd64"
+		url := "https://kind.sigs.k8s.io/dl/" + KindVersion + "/kind-" + operatingSystem + "-amd64"
 		fmt.Printf("Temp filename: %s\n", tmp_file.Name())
 		cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())	
 		err = cmd.Run()
 		if_error_exit(err)
 		// TODO: Need to find out how to display, the curl ongoing download details, on the terminal
 	
-		cmd = exec.Command("sudo", "mv", tmp_file.Name(), install_directory + "/kind")
+		cmd = exec.Command("sudo", "mv", tmp_file.Name(), installDirectory + "/kind")
 		_ = cmd.Run()
 		//if_error_exit(err) 
-		cmd = exec.Command("sudo", "chmod", "+rx", install_directory + "/kind")
+		cmd = exec.Command("sudo", "chmod", "+rx", installDirectory + "/kind")
 		_ = cmd.Run()
-		cmd = exec.Command("sudo", "chown", "root.root", install_directory + "/kind")
+		cmd = exec.Command("sudo", "chown", "root.root", installDirectory + "/kind")
 		
 		fmt.Println("The kind tool is set.")		
 	}
 }
 
-// setup_kubectl setup kubectl for k8s_version, in the install_directory if not available in the operating_system.
-func setup_kubectl(install_directory, k8s_version, operating_system string) {
+// setup_kubectl setup kubectl for k8sVersion, in the installDirectory if not available in the operatingSystem.
+func setup_kubectl(installDirectory, k8sVersion, operatingSystem string) {
  	// Check if the installation directory exist
-	_, err := os.Stat(install_directory)
+	_, err := os.Stat(installDirectory)
 	if_error_exit(err)
 	// If kubectl is not installed, install it.
-	_, err = os.Stat(install_directory + "/kubectl")
+	_, err = os.Stat(installDirectory + "/kubectl")
 	if err == nil {
 		fmt.Println("Kubectl is already installed in the System.")
 	} else if err != nil && os.IsNotExist(err) {
@@ -208,43 +208,43 @@ func setup_kubectl(install_directory, k8s_version, operating_system string) {
 		tmp_file, err := os.CreateTemp(".", "kubectl_setup")
 		if_error_exit(err)
 		// Download kubectl
-		url := "https://dl.k8s.io/" + k8s_version + "/bin/" + operating_system + "/amd64/kubectl"
+		url := "https://dl.k8s.io/" + k8sVersion + "/bin/" + operatingSystem + "/amd64/kubectl"
 		cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())
 		err = cmd.Run()
 		if_error_exit(err)
 		//mv, chmod, chown 
-		cmd = exec.Command("sudo", "mv", tmp_file.Name(), install_directory + "/kubectl")
+		cmd = exec.Command("sudo", "mv", tmp_file.Name(), installDirectory + "/kubectl")
 		_ = cmd.Run()
-		cmd = exec.Command("sudo", "chmod", "+rx", install_directory + "/kubectl")
+		cmd = exec.Command("sudo", "chmod", "+rx", installDirectory + "/kubectl")
 		_ = cmd.Run()
-		cmd = exec.Command("sudo", "chown", "root.root", install_directory + "/kubectl")
+		cmd = exec.Command("sudo", "chown", "root.root", installDirectory + "/kubectl")
 		_ = cmd.Run()
 
 		fmt.Println("The Kubectl tool is set.")
 	}
 }
 
-// setup_ginkgo setup ginkgo and e2e.test, for k8s_version, in the install_directory, if not available on the operating_system.
-func setup_ginkgo(install_directory, k8s_version, operating_system string) {
+// setup_ginkgo setup ginkgo and e2e.test, for k8sVersion, in the installDirectory, if not available on the operatingSystem.
+func setup_ginkgo(installDirectory, k8sVersion, operatingSystem string) {
 	//Create temp directory
 	tmp_dir, err := os.MkdirTemp(".", "ginkgo_setup_")  //I think this should only happen in case ginkgo and e2e.test are not installed. Fix later
 	if_error_exit(err)
 	defer os.RemoveAll(tmp_dir) //Clean up
 
-	_, ginkgo_exist := os.Stat(install_directory + "/ginkgo")
-	_, e2e_test_exist := os.Stat(install_directory + "/e2e.test")
+	_, ginkgo_exist := os.Stat(installDirectory + "/ginkgo")
+	_, e2e_test_exist := os.Stat(installDirectory + "/e2e.test")
 
 	if os.IsNotExist(ginkgo_exist) || os.IsNotExist(e2e_test_exist) {
 		fmt.Println("Downloading ginkgo and e2e.test ...")
-		url := "https://dl.k8s.io/" + k8s_version + "/kubernetes-test-" + operating_system + "-amd64.tar.gz"
-		out_file := tmp_dir + "/kubernetes-test-" + operating_system + "-amd64.tar.gz"
+		url := "https://dl.k8s.io/" + k8sVersion + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz"
+		out_file := tmp_dir + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz"
 
 		cmd := exec.Command("curl", "-L", url, "-o", out_file)
 		err = cmd.Run()
 		if_error_exit(err)
 
-		tar_file := tmp_dir + "/kubernetes-test-" + operating_system + "-amd64.tar.gz" 
-		cmd_string := "tar xvzf " + tar_file + " --directory " + install_directory + " --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test &> /dev/null"
+		tar_file := tmp_dir + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz" 
+		cmd_string := "tar xvzf " + tar_file + " --directory " + installDirectory + " --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test &> /dev/null"
 		cmd = exec.Command("bash", "-c", cmd_string)
 		err = cmd.Run()
 		if_error_exit(err)
@@ -257,7 +257,7 @@ func setup_ginkgo(install_directory, k8s_version, operating_system string) {
 }
 
 // setup_bpf2go install bpf2go binary.
-func setup_bpf2go(install_directory string) {
+func setup_bpf2go(installDirectory string) {
 	if ! command_exist("bpf2go") {
 		if ! command_exist("go") {
 			fmt.Println("Dependency not met: 'bpf2go' not installed and cannot install with 'go'")
@@ -265,12 +265,12 @@ func setup_bpf2go(install_directory string) {
 		} 
 		
 		fmt.Println("'bpf2go' not found, installing with 'go'")
-		_, err := os.Stat(install_directory)
+		_, err := os.Stat(installDirectory)
 		if err != nil && os.IsNotExist(err) {
 			log.Fatal(err)
 		}
-		// set GOBIN to bin_directory to ensure that binary is in search path	
-		_ = os.Setenv("GOBIN", install_directory)
+		// set GOBIN to binDirectory to ensure that binary is in search path	
+		_ = os.Setenv("GOBIN", installDirectory)
 		// remove GOPATH just to be sure
 		_ = os.Setenv("GOPATH", "")
 
@@ -288,78 +288,78 @@ func setup_bpf2go(install_directory string) {
 } 
 
 // Copy binaries from the net to the binaries directory.
-func install_binaries(bin_directory, k8s_version, operating_system, base_dir_path string, ) {
+func install_binaries(binDirectory, k8sVersion, operatingSystem, baseDirPath string, ) {
 	wd, err := os.Getwd()
 	if_error_exit(err)
 	
-	if wd != base_dir_path {
-		err = os.Chdir(base_dir_path)
+	if wd != baseDirPath {
+		err = os.Chdir(baseDirPath)
 		if_error_exit(err)
 	}
-	err = os.MkdirAll(bin_directory, 0755) 
+	err = os.MkdirAll(binDirectory, 0755) 
 
-	add_to_path(bin_directory) 
+	add_to_path(binDirectory) 
 
-	setup_kind(bin_directory, operating_system)
-	setup_kubectl(bin_directory, k8s_version, operating_system)
-	setup_ginkgo(bin_directory, k8s_version, operating_system)
-	setup_bpf2go(bin_directory)
+	setup_kind(binDirectory, operatingSystem)
+	setup_kubectl(binDirectory, k8sVersion, operatingSystem)
+	setup_ginkgo(binDirectory, k8sVersion, operatingSystem)
+	setup_bpf2go(binDirectory)
 }
 
 // detect_container_engine detect container engine, by default it is docker but developers might   
 // use real alternatives like podman. The project welcome both.
 func detect_container_engine() {
-	CONTAINER_ENGINE = "docker"
-	cmd := exec.Command(CONTAINER_ENGINE) 
+	containerEngine = "docker"
+	cmd := exec.Command(containerEngine) 
 	err := cmd.Run()
 	if err != nil {
 		// If docker is not available, let's check if podman exists
-		CONTAINER_ENGINE = "podman"
-		cmd = exec.Command(CONTAINER_ENGINE, "--help")
+		containerEngine = "podman"
+		cmd = exec.Command(containerEngine, "--help")
 		err = cmd.Run() 
 		if err != nil {
 			fmt.Println("The e2e tests currently support docker and podman as the container engine. Please install either of them")
 			os.Exit(1)
 		}
 	}
-	fmt.Println("Detected Container Engine:", CONTAINER_ENGINE)
+	fmt.Println("Detected Container Engine:", containerEngine)
 }
 
 // container_build build a container image for KPNG.
-func container_build(CONTAINER_FILE string, ci_mode bool) {
+func container_build(containerFile string, ciMode bool) {
 	// QUESTION to Jay: Is it necessary to have this variables in capital letters?
 	
 	// Running locally it's not necessary to show all info
 	QUIET_MODE := "--quiet"
-	if ci_mode == true {
+	if ciMode == true {
 		QUIET_MODE = ""
 	}
 
-	_, err := os.Stat(CONTAINER_FILE)
+	_, err := os.Stat(containerFile)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
 
-	err = os.Chdir(kpng_dir)
+	err = os.Chdir(kpngDir)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if QUIET_MODE == "" {
-		cmd := exec.Command(CONTAINER_ENGINE, "build", "-t", KpngImageTagName, "-f", CONTAINER_FILE, ".")
+		cmd := exec.Command(containerEngine, "build", "-t", KpngImageTagName, "-f", containerFile, ".")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		cmd := exec.Command(CONTAINER_ENGINE, "build", QUIET_MODE, "-t", KpngImageTagName, "-f", CONTAINER_FILE, ".")
+		cmd := exec.Command(containerEngine, "build", QUIET_MODE, "-t", KpngImageTagName, "-f", containerFile, ".")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	err = os.Chdir(kpng_dir + "/hack")
+	err = os.Chdir(kpngDir + "/hack")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -367,27 +367,27 @@ func container_build(CONTAINER_FILE string, ci_mode bool) {
 }
 
 // set_e2e_dir set E2E directory.
-func set_e2e_dir(e2e_dir string) {
+func set_e2e_dir(e2eDir string) {
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = os.Chdir(kpng_dir + "/hack")
+	err = os.Chdir(kpngDir + "/hack")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	_, err = os.Stat(e2e_dir)
+	_, err = os.Stat(e2eDir)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
 
-	_, err = os.Stat(e2e_dir + "/artifacts") 
+	_, err = os.Stat(e2eDir + "/artifacts") 
 	if err == nil {
 		fmt.Println("The directory \"artifacts\" already exist!")
 	} else if err != nil && os.IsNotExist(err) {
-		err = os.Mkdir(e2e_dir + "/artifacts", 0755)
+		err = os.Mkdir(e2eDir + "/artifacts", 0755)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -400,13 +400,13 @@ func set_e2e_dir(e2e_dir string) {
 }
 
 // prepare_container prepare container based on the dockerfile. 
-func prepare_container(dockerfile string, ci_mode bool) {
+func prepare_container(dockerfile string, ciMode bool) {
 	detect_container_engine()
-	container_build(dockerfile, ci_mode) 
+	container_build(dockerfile, ciMode) 
 }
 
 // create_cluster create a kind cluster.
-func create_cluster(cluster_name, bin_dir, ip_family, artifacts_directory string, ci_mode bool) {
+func create_cluster(clusterName, binDir, ipFamily, artifactsDirectory string, ciMode bool) {
 	type KindConfigData struct {
 		IpFamily string
 		ClusterCidr string
@@ -426,12 +426,12 @@ nodes:
 - role: worker	
 `	
 	var (
-		kind = bin_dir + "/kind"
-		kubectl = bin_dir + "/kubectl"
+		kind = binDir + "/kind"
+		kubectl = binDir + "/kubectl"
 	)
 
 
-	_, err := os.Stat(bin_dir)
+	_, err := os.Stat(binDir)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
@@ -446,17 +446,17 @@ nodes:
 		log.Fatal(err)
 	}
 
-	cmd_string := kind + " get clusters | grep -q " + cluster_name
+	cmd_string := kind + " get clusters | grep -q " + clusterName
 	cmd := exec.Command("bash", "-c", cmd_string)
 	err = cmd.Run()
 	if err == nil {
-		cmd_string = kind + " delete cluster --name " + cluster_name
+		cmd_string = kind + " delete cluster --name " + clusterName
 		cmd = exec.Command("bash", "-c", cmd_string)
 		err = cmd.Run()
 		if err != nil {
-			log.Fatalf("Cannot delete cluster %s\n", cluster_name, err)
+			log.Fatalf("Cannot delete cluster %s\n", clusterName, err)
 		}
-		fmt.Printf("Previous cluster %s deleted.\n", cluster_name)
+		fmt.Printf("Previous cluster %s deleted.\n", clusterName)
 	}
 
 	// Default Log level for all components in test clusters
@@ -465,7 +465,7 @@ nodes:
 		kind_cluster_log_level = "4"
 	}
 	kind_log_level := "-v3"
-	if ci_mode == true {
+	if ciMode == true {
 		kind_log_level = "-v7"
 	}
 /*
@@ -476,13 +476,13 @@ nodes:
 */
 	var CLUSTER_CIDR, SERVICE_CLUSTER_IP_RANGE string
 	
-	switch ip_family {
+	switch ipFamily {
 	case "ipv4":
 		CLUSTER_CIDR = ClusterCidrV4
         SERVICE_CLUSTER_IP_RANGE = ServiceClusterIpRangeV4
 	}
 
-	fmt.Printf("Preparing to setup %s cluster ...\n", cluster_name)
+	fmt.Printf("Preparing to setup %s cluster ...\n", clusterName)
 	// Create cluster
 	// Create the config file
 	tmpl, err := template.New("kind_config_template").Parse(KIND_CONFIG_TEMPLATE)	
@@ -490,12 +490,12 @@ nodes:
 		log.Fatalf("Unable to create template %v", err)
 	}
 	kind_config_template_data := KindConfigData {
-		IpFamily:			 	ip_family,
+		IpFamily:			 	ipFamily,
 		ClusterCidr:			CLUSTER_CIDR,
 		ServiceClusterIpRange:	SERVICE_CLUSTER_IP_RANGE,
 	}
 
-	yamlDestPath := artifacts_directory + "/kind-config.yaml"
+	yamlDestPath := artifactsDirectory + "/kind-config.yaml"
 	f, err := os.Create(yamlDestPath)
 	if err != nil {
 		log.Fatal(err)
@@ -507,12 +507,12 @@ nodes:
 	
 	cmd_string_set := []string {
 		kind + " create cluster ",
-		"--name " + cluster_name,
+		"--name " + clusterName,
 		" --image " + KindestNodeImage + ":" + E2eK8sVersion,
 		" --retain",
-		" --wait=1m ",
+		" --wait=20m ",
 		kind_log_level,
-		" --config=" + artifacts_directory + "/kind-config.yaml",
+		" --config=" + artifactsDirectory + "/kind-config.yaml",
 	}
 	cmd_string = ""
 	for _, s := range cmd_string_set {
@@ -522,7 +522,7 @@ nodes:
 	cmd = exec.Command("bash", "-c", cmd_string)
 	err = cmd.Run()
 	if err != nil {
-		log.Fatalf("Can not create kind cluster %s\n", cluster_name, err)
+		log.Fatalf("Can not create kind cluster %s\n", clusterName, err)
 	} 
 
 	// Patch kube-proxy to set the verbosity level
@@ -543,7 +543,7 @@ nodes:
 	fmt.Println("Kube-proxy patched! Guys how can I test this? To find out if it was really successful.")
 
 	// Generate the file kubeconfig.conf on the artifacts directory
-	cmd_string = kind + " get kubeconfig --internal --name " + cluster_name +" > " + artifacts_directory + "/kubeconfig.conf"
+	cmd_string = kind + " get kubeconfig --internal --name " + clusterName +" > " + artifactsDirectory + "/kubeconfig.conf"
 	cmd = exec.Command("bash", "-c", cmd_string)
 	err = cmd.Run()
 	if err != nil {
@@ -551,24 +551,24 @@ nodes:
 	}
 
 	// Generate the file KubeconfigTests on the artifacts directory
-	cmd_string = kind + " get kubeconfig --name " + cluster_name +" > " + artifacts_directory + "/" + KubeconfigTests
+	cmd_string = kind + " get kubeconfig --name " + clusterName +" > " + artifactsDirectory + "/" + KubeconfigTests
 	cmd = exec.Command("bash", "-c", cmd_string)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Failed to create the file KubeconfigTests.\n", err)
 	}
 
-	fmt.Printf("Cluster %s is created.\n", cluster_name)
+	fmt.Printf("Cluster %s is created.\n", clusterName)
 
 }
 
 // wait_until_cluster_is_ready wait pods with selector k8s-app=kube-dns be ready and operational.
-func wait_until_cluster_is_ready(cluster_name, bin_dir string, ci_mode bool) {
+func wait_until_cluster_is_ready(clusterName, binDir string, ciMode bool) {
 
-	k8s_context := "kind-" + cluster_name
-	kubectl := bin_dir + "/kubectl"
+	k8s_context := "kind-" + clusterName
+	kubectl := binDir + "/kubectl"
 
-	_, err := os.Stat(bin_dir)
+	_, err := os.Stat(binDir)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
@@ -585,7 +585,7 @@ func wait_until_cluster_is_ready(cluster_name, bin_dir string, ci_mode bool) {
 		log.Fatal(err)
 	}
 	
-	if ci_mode == true {
+	if ciMode == true {
 		cmd = exec.Command("kubectl", "--context", k8s_context, "get", "nodes", "-o", "wide")
 		err = cmd.Run()
 		if err != nil {
@@ -598,7 +598,7 @@ func wait_until_cluster_is_ready(cluster_name, bin_dir string, ci_mode bool) {
 			log.Fatal("Error getting pods from all namespaces.", err)
 		}
 	}
-	fmt.Printf("%s is operational.\n",cluster_name)
+	fmt.Printf("%s is operational.\n",clusterName)
 }
 
 // install_kpng install KPNG following these steps:
@@ -606,17 +606,17 @@ func wait_until_cluster_is_ready(cluster_name, bin_dir string, ci_mode bool) {
 //   - load kpng container image
 //   - create service account, clusterbinding and configmap for kpng
 //   - deploy kpng from the template generated
-func install_kpng(cluster_name, bin_dir string) {
+func install_kpng(clusterName, binDir string) {
 
-	k8s_context := "kind-" + cluster_name
-	kubectl 	:= bin_dir + "/kubectl"
-	kind		:= bin_dir + "/kind"
+	k8s_context := "kind-" + clusterName
+	kubectl 	:= binDir + "/kubectl"
+	kind		:= binDir + "/kind"
 	
-	artifacts_directory := os.Getenv("E2E_ARTIFACTS")
+	artifactsDirectory := os.Getenv("E2E_ARTIFACTS")
 	E2E_BACKEND := os.Getenv("E2E_BACKEND")
 	E2E_DEPLOYMENT_MODEL := os.Getenv("E2E_DEPLOYMENT_MODEL")
 
-	_, err := os.Stat(bin_dir)
+	_, err := os.Stat(binDir)
 	if err !=nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
@@ -636,7 +636,7 @@ func install_kpng(cluster_name, bin_dir string) {
 
 	// Load kpng container image
 	// Preload kpng image 
-	cmd = exec.Command(kind, "load", "docker-image", KpngImageTagName, "--name", cluster_name)
+	cmd = exec.Command(kind, "load", "docker-image", KpngImageTagName, "--name", clusterName)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error loading image to kind.\n", err)
@@ -658,7 +658,7 @@ func install_kpng(cluster_name, bin_dir string) {
 	}
 	fmt.Println("Created clusterrolebinding", ClusterRoleBindingName)
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "configmap", ConfigMapName, "--namespace", Namespace, "--from-file", artifacts_directory + "/kubeconfig.conf")
+	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "configmap", ConfigMapName, "--namespace", Namespace, "--from-file", artifactsDirectory + "/kubeconfig.conf")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error creating configmap", ConfigMapName)
@@ -687,18 +687,18 @@ func install_kpng(cluster_name, bin_dir string) {
     _ = os.Setenv("deployment_model", E2E_DEPLOYMENT_MODEL)
     _ = os.Setenv("e2e_server_args", E2E_SERVER_ARGS)
 
-	// TODO: Change kpng_dir to SCRIPT_DIR
-	//go run "${SCRIPT_DIR}"/kpng-ds-yaml-gen.go "${SCRIPT_DIR}"/kpng-deployment-ds-template.txt  "${artifacts_directory}"/kpng-deployment-ds.yaml	
+	// TODO: Change kpngDir to SCRIPT_DIR
+	//go run "${SCRIPT_DIR}"/kpng-ds-yaml-gen.go "${SCRIPT_DIR}"/kpng-deployment-ds-template.txt  "${artifactsDirectory}"/kpng-deployment-ds.yaml	
 	//if_error_exit "error generating kpng deployment YAML"
-	SCRIPT_DIR := kpng_dir + "/hack"
+	SCRIPT_DIR := kpngDir + "/hack"
 
-	cmd = exec.Command("go", "run", SCRIPT_DIR + "/kpng-ds-yaml-gen.go", SCRIPT_DIR + "/kpng-deployment-ds-template.txt", artifacts_directory + "/kpng-deployment-ds.yaml")
+	cmd = exec.Command("go", "run", SCRIPT_DIR + "/kpng-ds-yaml-gen.go", SCRIPT_DIR + "/kpng-deployment-ds-template.txt", artifactsDirectory + "/kpng-deployment-ds.yaml")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error generating kpng deployment YAML.", err)
 	}
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "-f", artifacts_directory + "/kpng-deployment-ds.yaml")
+	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "-f", artifactsDirectory + "/kpng-deployment-ds.yaml")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error creating kpng deployment \n", err)
@@ -715,25 +715,25 @@ func install_kpng(cluster_name, bin_dir string) {
 }
 
 // run_tests execute the tests with ginkgo.
-func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, backend string, include_specific_failed_tests bool) {
+func run_tests(e2eDir, binDir string, parallelGinkgoTests bool, ipFamily, backend string, includeSpecificFailedTests bool) {
 
-	artifacts_directory := e2e_dir + "/artifacts"
-	ginkgo := bin_dir + "/ginkgo"
-	e2e_test := bin_dir + "/e2e.test"
+	artifactsDirectory := e2eDir + "/artifacts"
+	ginkgo := binDir + "/ginkgo"
+	e2e_test := binDir + "/e2e.test"
 
-	_, err := os.Stat(artifacts_directory + "/" + KubeconfigTests)
+	_, err := os.Stat(artifactsDirectory + "/" + KubeconfigTests)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
-	_, err = os.Stat(bin_dir)
+	_, err = os.Stat(binDir)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
-	_, err = os.Stat(bin_dir + "/e2e.test")
+	_, err = os.Stat(binDir + "/e2e.test")
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
-	_, err = os.Stat(bin_dir + "/ginkgo")
+	_, err = os.Stat(binDir + "/ginkgo")
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
@@ -749,9 +749,9 @@ func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, b
 	
 	var skip_set_name,  skip_set_ref string
 
-	if include_specific_failed_tests == false {
+	if includeSpecificFailedTests == false {
 	// Find ip_type and backend specific skip sets	
-		skip_set_name = "GINKGO_SKIP_" + ip_family + "_" + backend + "_TEST"
+		skip_set_name = "GINKGO_SKIP_" + ipFamily + "_" + backend + "_TEST"
 		skip_set_ref = skip_set_name
 		if len(strings.TrimSpace(skip_set_ref)) > 0 {
 			ginkgo_skip = ginkgo_skip + "|" + skip_set_ref
@@ -766,7 +766,7 @@ func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, b
 	_ = os.Setenv("KUBE_CONTAINER_RUNTIME_NAME", "containerd")
 
 	cmd := exec.Command(ginkgo, "--nodes", strconv.Itoa(GinkgoNumberOfNodes), "--focus", ginkgo_focus, "--skip", ginkgo_skip, e2e_test, 
-		"--kubeconfig", artifacts_directory + "/" + KubeconfigTests, "--provider", GinkgoProvider, "--dump-logs-on-failure", strconv.FormatBool(GinkgoDumpLogsOnFailure), 
+		"--kubeconfig", artifactsDirectory + "/" + KubeconfigTests, "--provider", GinkgoProvider, "--dump-logs-on-failure", strconv.FormatBool(GinkgoDumpLogsOnFailure), 
 	 	"--report-dir", GinkgoReportDir, "--disable-log-dump", strconv.FormatBool(GinkgoDisableLogDump))
 	err = cmd.Run()
 	
@@ -779,45 +779,45 @@ func run_tests(e2e_dir, bin_dir string, parallel_ginkgo_tests bool, ip_family, b
 }
 
 // create_infrastructure_and_run_tests.
-func create_imfrastructure_and_run_tests(e2e_dir, ip_family, backend, bin_dir, suffix string, developer_mode, ci_mode bool, deployment_model string, export_metrics, include_specific_failed_tests bool) {
+func create_imfrastructure_and_run_tests(e2eDir, ipFamily, backend, binDir, suffix string, developerMode, ciMode bool, deploymentModel string, exportMetrics, includeSpecificFailedTests bool) {
 
-	artifacts_directory := e2e_dir + "/artifacts"
-	cluster_name := "kpng-e2e-" + ip_family + "-" + backend + suffix
+	artifactsDirectory := e2eDir + "/artifacts"
+	clusterName := "kpng-e2e-" + ipFamily + "-" + backend + suffix
 
-	_ = os.Setenv("E2E_DIR", e2e_dir)
-    _ = os.Setenv("E2E_ARTIFACTS", artifacts_directory)
-    _ = os.Setenv("E2E_CLUSTER_NAME", cluster_name)
-    _ = os.Setenv("E2E_IP_FAMILY", ip_family)
+	_ = os.Setenv("E2E_DIR", e2eDir)
+    _ = os.Setenv("E2E_ARTIFACTS", artifactsDirectory)
+    _ = os.Setenv("E2E_CLUSTER_NAME", clusterName)
+    _ = os.Setenv("E2E_IP_FAMILY", ipFamily)
     _ = os.Setenv("E2E_BACKEND", backend)
-    _ = os.Setenv("E2E_DEPLOYMENT_MODEL", deployment_model)
-    _ = os.Setenv("E2E_EXPORT_METRICS", strconv.FormatBool(export_metrics))
+    _ = os.Setenv("E2E_DEPLOYMENT_MODEL", deploymentModel)
+    _ = os.Setenv("E2E_EXPORT_METRICS", strconv.FormatBool(exportMetrics))
 	
-	_, err := os.Stat(artifacts_directory)
+	_, err := os.Stat(artifactsDirectory)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
 
-	_, err = os.Stat(bin_dir)
+	_, err = os.Stat(binDir)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatal(err)
 	}
 
-	fmt.Println("Cluster name: ", cluster_name)
+	fmt.Println("Cluster name: ", clusterName)
 
-	create_cluster(cluster_name, bin_dir, ip_family, artifacts_directory, ci_mode)
-	wait_until_cluster_is_ready(cluster_name, bin_dir, ci_mode)
+	create_cluster(clusterName, binDir, ipFamily, artifactsDirectory, ciMode)
+	wait_until_cluster_is_ready(clusterName, binDir, ciMode)
 
-	err = os.WriteFile(e2e_dir + "/clustername", []byte(cluster_name), 0664)
+	err = os.WriteFile(e2eDir + "/clustername", []byte(clusterName), 0664)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if backend != "not-kpng" {
-		install_kpng(cluster_name, bin_dir)
+		install_kpng(clusterName, binDir)
 	}
 /*
-	if developer_mode == true {
-		run_tests(e2e_dir, bin_dir, false, ip_family, backend, include_specific_failed_tests)
+	if developerMode == true {
+		run_tests(e2eDir, binDir, false, ipFamily, backend, includeSpecificFailedTests)
 	}
 */
 }
@@ -825,18 +825,18 @@ func create_imfrastructure_and_run_tests(e2e_dir, ip_family, backend, bin_dir, s
 func main() {
 	fmt.Println("Hello :)")
 
-	var ci_mode bool = true
+	var ciMode bool = true
 	var dockerfile string
-	var e2e_dir string = ""
-	var bin_dir string = ""	
+	var e2eDir string = ""
+	var binDir string = ""	
 	var (
-		ip_family		 				= "ipv4"
+		ipFamily		 				= "ipv4"
 		backend							= "iptables"
 		suffix							= ""
-		developer_mode					= true
-		deployment_model				= "single-process-per-node"
-		export_metrics					= false 
-		include_specific_failed_tests	= true
+		developerMode					= true
+		deploymentModel				= "single-process-per-node"
+		exportMetrics					= false 
+		includeSpecificFailedTests	= true
 		cluster_count					= 1
 	)
 	
@@ -844,16 +844,16 @@ func main() {
 	wd, err := os.Getwd()
 	if_error_exit(err)
 	base_dir := wd //How can I have this variable as a constant??? 
-	kpng_dir = path.Dir(wd)
+	kpngDir = path.Dir(wd)
 
 
-	if e2e_dir == "" {
+	if e2eDir == "" {
 		pwd, err := os.Getwd()
 		if_error_exit(err)
-		e2e_dir = pwd + "/temp_go/e2e"
+		e2eDir = pwd + "/temp_go/e2e"
 	} 
-	if bin_dir == "" {
-		bin_dir = e2e_dir + "/bin"
+	if binDir == "" {
+		binDir = e2eDir + "/bin"
 	}
 
 	// Get the OS
@@ -874,16 +874,16 @@ func main() {
 	if_error_exit(err)
 	dockerfile = strings.TrimSpace(buffer.String()) + "/Dockerfile"
 
-	install_binaries(bin_dir, KubernetesVersion, OS, base_dir)
-	prepare_container(dockerfile, ci_mode)
+	install_binaries(binDir, KubernetesVersion, OS, base_dir)
+	prepare_container(dockerfile, ciMode)
 
 	tmp_suffix := ""
 	if cluster_count == 1 {
 		if len(suffix) > 0 {
 			tmp_suffix = "-" + suffix
 		}
-		set_e2e_dir(e2e_dir + tmp_suffix)
+		set_e2e_dir(e2eDir + tmp_suffix)
 	}
 
-	create_imfrastructure_and_run_tests(e2e_dir, ip_family, backend, bin_dir, suffix, developer_mode, ci_mode, deployment_model, export_metrics, include_specific_failed_tests)
+	create_imfrastructure_and_run_tests(e2eDir, ipFamily, backend, binDir, suffix, developerMode, ciMode, deploymentModel, exportMetrics, includeSpecificFailedTests)
 }

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -21,6 +21,10 @@ func if_error_exit(error_msg error) {
 	}
 } 
 
+func add_to_path(directory string) {
+
+}
+
 func set_sysctl(attribute string, value int) {
     // Description:
     // Set a sysctl attribute to value
@@ -63,9 +67,53 @@ func set_host_network_settings(ip_family string) {
 	}	
 }
 
+func install_binaries(bin_directory string, k8s_version string, os string) {
+    
+    // Description:
+    // Copy binaries from the net to binaries directory
+    //
+    // Arguments:
+    //   arg1: binary directory, path to where ginko will be installed
+    //   arg2: Kubernetes version
+    //  arg3: OS, name of the operating system
+	/////////////////////////////////////////////////////////////////////////////////
+	wd, err := os.Getwd()
+	if_error_exit(err)
+	
+	if wd != basename_dir {
+		err = os.Chdir(basename_dir)
+		if_error_exit
+	}
+	os.MkdirAll() ...
+
+}
+
+
+
+
 
 func main() {
 	fmt.Println("Ola :-)")
-	
+	var e2e_dir string = ""
+	var bin_dir string = ""	
+
+	wd, err := os.Getwd
+	if_error_exit(err)
+	const basename_dir = wd
+
+
+	if e2e_dir == "" {
+		pwd, err := os.Getwd()
+		if_error_exit(err)
+		e2e_dir = pwd + "/temp_go/e2e"
+	} 
+	if bin_dir == "" {
+		bin_dir = e2e_dir + "/bin"
+	}
+
+
+
+
+
 
 }

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -57,8 +57,8 @@ func ifErrorExit(errorMsg error) {
 
 // commandExist check if a binary(cmdTest) exists. It returns True or False 
 func commandExist(cmdTest string) bool {
-	cmd_script := "command -v " + cmdTest + " > /dev/null 2>&1"
-	cmd := exec.Command("bash", "-c", cmd_script)
+	cmdScript := "command -v " + cmdTest + " > /dev/null 2>&1"
+	cmd := exec.Command("bash", "-c", cmdScript)
 	err := cmd.Run()
 	
 	if err == nil {
@@ -83,20 +83,20 @@ func addToPath(directory string) {
 	// I believe the package regexp can be used. Couldn't figure out the right pattern. For now 
 	// will use the following approach
 	// TODO(Maybe!): Check using the regexp package
-	path_set := strings.Split(path, ":") 
-	dir_path_exist := false
-	for _, s := range path_set {
+	pathSet := strings.Split(path, ":") 
+	dirPathExist := false
+	for _, s := range pathSet {
 		if directory == s {
-			dir_path_exist = true
+			dirPathExist = true
 			break
 		}
 	}
 
 	fmt.Println("New directory: ", directory)
-	if !dir_path_exist {
+	if !dirPathExist {
 		fmt.Println("The directory is NOT in the $PATH env variable! :(")
-		updated_path := path + ":" + directory
-		err = os.Setenv("PATH", updated_path)
+		updatedPath := path + ":" + directory
+		err = os.Setenv("PATH", updatedPath)
 		ifErrorExit(err)
 		fmt.Println(os.Getenv("PATH"))
 		fmt.Println("The directory is NOW in the $PATH env variable! hooray:)")
@@ -113,14 +113,14 @@ func setSysctl(attribute string, value int) {
 	err := cmd.Run()
 	ifErrorExit(err)
 
-	result_str := strings.TrimSpace(buffer.String())
-	result_int, err := strconv.Atoi(result_str)
+	resultStr := strings.TrimSpace(buffer.String())
+	resultInt, err := strconv.Atoi(resultStr)
 	
-	fmt.Printf("Checking sysctls value: %d vs result: %d\n", value, result_int)
-	if value != result_int {
+	fmt.Printf("Checking sysctls value: %d vs result: %d\n", value, resultInt)
+	if value != resultInt {
 		fmt.Printf("Setting: \"sysctl -w %s=%d\"\n", attribute, value)
-		variable_value := attribute + "=" + strconv.Itoa(value)
-		cmd = exec.Command("sudo", "sysctl", "-w", variable_value)
+		variableValue := attribute + "=" + strconv.Itoa(value)
+		cmd = exec.Command("sudo", "sysctl", "-w", variableValue)
 		err = cmd.Run()
 		ifErrorExit(err)
 	}
@@ -170,18 +170,18 @@ func setupKind(installDirectory, operatingSystem string) {
 		fmt.Println()
 		fmt.Println("Downloading kind ...")
 
-		tmp_file, err := os.CreateTemp("/tmp", "kind_setup")
+		tmpFile, err := os.CreateTemp("/tmp", "kind_setup")
 		ifErrorExit(err)
-		defer os.Remove(tmp_file.Name()) // Clean up. QUESTION: As we will end up moving the temp file, is this necessary? 
+		defer os.Remove(tmpFile.Name()) // Clean up. QUESTION: As we will end up moving the temp file, is this necessary? 
 	
 		url := "https://kind.sigs.k8s.io/dl/" + KindVersion + "/kind-" + operatingSystem + "-amd64"
-		fmt.Printf("Temp filename: %s\n", tmp_file.Name())
-		cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())	
+		fmt.Printf("Temp filename: %s\n", tmpFile.Name())
+		cmd := exec.Command("curl", "-L", url, "-o", tmpFile.Name())	
 		err = cmd.Run()
 		ifErrorExit(err)
 		// TODO: Need to find out how to display, the curl ongoing download details, on the terminal
 	
-		cmd = exec.Command("sudo", "mv", tmp_file.Name(), installDirectory + "/kind")
+		cmd = exec.Command("sudo", "mv", tmpFile.Name(), installDirectory + "/kind")
 		_ = cmd.Run()
 		//ifErrorExit(err) 
 		cmd = exec.Command("sudo", "chmod", "+rx", installDirectory + "/kind")
@@ -205,15 +205,15 @@ func setupKubectl(installDirectory, k8sVersion, operatingSystem string) {
 		// Show message "Downloading kubectl ..."
 		fmt.Println("Downloading kubectl ...") 
 		// Create tem file
-		tmp_file, err := os.CreateTemp(".", "kubectl_setup")
+		tmpFile, err := os.CreateTemp(".", "kubectl_setup")
 		ifErrorExit(err)
 		// Download kubectl
 		url := "https://dl.k8s.io/" + k8sVersion + "/bin/" + operatingSystem + "/amd64/kubectl"
-		cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())
+		cmd := exec.Command("curl", "-L", url, "-o", tmpFile.Name())
 		err = cmd.Run()
 		ifErrorExit(err)
 		//mv, chmod, chown 
-		cmd = exec.Command("sudo", "mv", tmp_file.Name(), installDirectory + "/kubectl")
+		cmd = exec.Command("sudo", "mv", tmpFile.Name(), installDirectory + "/kubectl")
 		_ = cmd.Run()
 		cmd = exec.Command("sudo", "chmod", "+rx", installDirectory + "/kubectl")
 		_ = cmd.Run()
@@ -227,25 +227,25 @@ func setupKubectl(installDirectory, k8sVersion, operatingSystem string) {
 // setupGinkgo setup ginkgo and e2e.test, for k8sVersion, in the installDirectory, if not available on the operatingSystem.
 func setupGinkgo(installDirectory, k8sVersion, operatingSystem string) {
 	//Create temp directory
-	tmp_dir, err := os.MkdirTemp(".", "ginkgo_setup_")  //I think this should only happen in case ginkgo and e2e.test are not installed. Fix later
+	tmpDir, err := os.MkdirTemp(".", "ginkgo_setup_")  //I think this should only happen in case ginkgo and e2e.test are not installed. Fix later
 	ifErrorExit(err)
-	defer os.RemoveAll(tmp_dir) //Clean up
+	defer os.RemoveAll(tmpDir) //Clean up
 
-	_, ginkgo_exist := os.Stat(installDirectory + "/ginkgo")
-	_, e2e_test_exist := os.Stat(installDirectory + "/e2e.test")
+	_, ginkgoExist := os.Stat(installDirectory + "/ginkgo")
+	_, e2eTestExist := os.Stat(installDirectory + "/e2e.test")
 
-	if os.IsNotExist(ginkgo_exist) || os.IsNotExist(e2e_test_exist) {
+	if os.IsNotExist(ginkgoExist) || os.IsNotExist(e2eTestExist) {
 		fmt.Println("Downloading ginkgo and e2e.test ...")
 		url := "https://dl.k8s.io/" + k8sVersion + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz"
-		out_file := tmp_dir + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz"
+		outFile := tmpDir + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz"
 
-		cmd := exec.Command("curl", "-L", url, "-o", out_file)
+		cmd := exec.Command("curl", "-L", url, "-o", outFile)
 		err = cmd.Run()
 		ifErrorExit(err)
 
-		tar_file := tmp_dir + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz" 
-		cmd_string := "tar xvzf " + tar_file + " --directory " + installDirectory + " --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test &> /dev/null"
-		cmd = exec.Command("bash", "-c", cmd_string)
+		tarFile := tmpDir + "/kubernetes-test-" + operatingSystem + "-amd64.tar.gz" 
+		cmdString := "tar xvzf " + tarFile + " --directory " + installDirectory + " --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test &> /dev/null"
+		cmd = exec.Command("bash", "-c", cmdString)
 		err = cmd.Run()
 		ifErrorExit(err)
 
@@ -330,9 +330,9 @@ func containerBuild(containerFile string, ciMode bool) {
 	// QUESTION to Jay: Is it necessary to have this variables in capital letters?
 	
 	// Running locally it's not necessary to show all info
-	QUIET_MODE := "--quiet"
+	QuietMode := "--quiet"
 	if ciMode == true {
-		QUIET_MODE = ""
+		QuietMode = ""
 	}
 
 	_, err := os.Stat(containerFile)
@@ -345,14 +345,14 @@ func containerBuild(containerFile string, ciMode bool) {
 		log.Fatal(err)
 	}
 
-	if QUIET_MODE == "" {
+	if QuietMode == "" {
 		cmd := exec.Command(containerEngine, "build", "-t", KpngImageTagName, "-f", containerFile, ".")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		cmd := exec.Command(containerEngine, "build", QUIET_MODE, "-t", KpngImageTagName, "-f", containerFile, ".")
+		cmd := exec.Command(containerEngine, "build", QuietMode, "-t", KpngImageTagName, "-f", containerFile, ".")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal(err)
@@ -413,7 +413,7 @@ func createCluster(clusterName, binDir, ipFamily, artifactsDirectory string, ciM
 		ServiceClusterIpRange string
 	}
 
-	const KIND_CONFIG_TEMPLATE = `
+	const KindConfigTemplate = `
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
@@ -446,12 +446,12 @@ nodes:
 		log.Fatal(err)
 	}
 
-	cmd_string := kind + " get clusters | grep -q " + clusterName
-	cmd := exec.Command("bash", "-c", cmd_string)
+	cmdString := kind + " get clusters | grep -q " + clusterName
+	cmd := exec.Command("bash", "-c", cmdString)
 	err = cmd.Run()
 	if err == nil {
-		cmd_string = kind + " delete cluster --name " + clusterName
-		cmd = exec.Command("bash", "-c", cmd_string)
+		cmdString = kind + " delete cluster --name " + clusterName
+		cmd = exec.Command("bash", "-c", cmdString)
 		err = cmd.Run()
 		if err != nil {
 			log.Fatalf("Cannot delete cluster %s\n", clusterName, err)
@@ -460,39 +460,39 @@ nodes:
 	}
 
 	// Default Log level for all components in test clusters
-	kind_cluster_log_level := os.Getenv("KIND_CLUSTER_LOG_LEVEL")
-	if strings.TrimSpace(kind_cluster_log_level) == "" {
-		kind_cluster_log_level = "4"
+	kindClusterLogLevel := os.Getenv("KIND_CLUSTER_LOG_LEVEL")
+	if strings.TrimSpace(kindClusterLogLevel) == "" {
+		kindClusterLogLevel = "4"
 	}
-	kind_log_level := "-v3"
+	kindLogLevel := "-v3"
 	if ciMode == true {
-		kind_log_level = "-v7"
+		kindLogLevel = "-v7"
 	}
 /*
 	// Potentially enable --logging-format
-	scheduler_extra_args := "\"v\": \"" + kind_cluster_log_level + "\""
-	controllerManager_extra_args := "\"v\": \"" + kind_cluster_log_level + "\""
-	apiServer_extra_args := "\"v\": \"" + kind_cluster_log_level + "\""
+	scheduler_extra_args := "\"v\": \"" + kindClusterLogLevel + "\""
+	controllerManager_extra_args := "\"v\": \"" + kindClusterLogLevel + "\""
+	apiServer_extra_args := "\"v\": \"" + kindClusterLogLevel + "\""
 */
-	var CLUSTER_CIDR, SERVICE_CLUSTER_IP_RANGE string
+	var clusterCidr, serviceClusterIpRange string
 	
 	switch ipFamily {
 	case "ipv4":
-		CLUSTER_CIDR = ClusterCidrV4
-        SERVICE_CLUSTER_IP_RANGE = ServiceClusterIpRangeV4
+		clusterCidr = ClusterCidrV4
+        serviceClusterIpRange = ServiceClusterIpRangeV4
 	}
 
 	fmt.Printf("Preparing to setup %s cluster ...\n", clusterName)
 	// Create cluster
 	// Create the config file
-	tmpl, err := template.New("kind_config_template").Parse(KIND_CONFIG_TEMPLATE)	
+	tmpl, err := template.New("kind_config_template").Parse(KindConfigTemplate)	
 	if err != nil {
 		log.Fatalf("Unable to create template %v", err)
 	}
-	kind_config_template_data := KindConfigData {
+	kindConfigTemplateData := KindConfigData {
 		IpFamily:			 	ipFamily,
-		ClusterCidr:			CLUSTER_CIDR,
-		ServiceClusterIpRange:	SERVICE_CLUSTER_IP_RANGE,
+		ClusterCidr:			clusterCidr,
+		ServiceClusterIpRange:	serviceClusterIpRange,
 	}
 
 	yamlDestPath := artifactsDirectory + "/kind-config.yaml"
@@ -500,42 +500,42 @@ nodes:
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = tmpl.Execute(f, kind_config_template_data)
+	err = tmpl.Execute(f, kindConfigTemplateData)
 	if err != nil {
 		log.Fatal(err)
 	}
 	
-	cmd_string_set := []string {
+	cmdStringSet := []string {
 		kind + " create cluster ",
 		"--name " + clusterName,
 		" --image " + KindestNodeImage + ":" + E2eK8sVersion,
 		" --retain",
 		" --wait=20m ",
-		kind_log_level,
+		kindLogLevel,
 		" --config=" + artifactsDirectory + "/kind-config.yaml",
 	}
-	cmd_string = ""
-	for _, s := range cmd_string_set {
-		cmd_string += s
+	cmdString = ""
+	for _, s := range cmdStringSet {
+		cmdString += s
 	}
 	
-	cmd = exec.Command("bash", "-c", cmd_string)
+	cmd = exec.Command("bash", "-c", cmdString)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Can not create kind cluster %s\n", clusterName, err)
 	} 
 
 	// Patch kube-proxy to set the verbosity level
-	cmd_string_set = []string {
+	cmdStringSet = []string {
 		kubectl + " patch -n kube-system daemonset/kube-proxy ",
 		"--type='json' ",
-		"-p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/command/-\", \"value\": \"--v=" + kind_cluster_log_level + "\" }]'",
+		"-p='[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/command/-\", \"value\": \"--v=" + kindClusterLogLevel + "\" }]'",
 	}
-	cmd_string = ""
-	for _, s := range cmd_string_set {
-		cmd_string += s
+	cmdString = ""
+	for _, s := range cmdStringSet {
+		cmdString += s
 	}
-	cmd = exec.Command("bash", "-c", cmd_string)
+	cmd = exec.Command("bash", "-c", cmdString)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Cannot patch kube-proxy.\n", err)
@@ -543,16 +543,16 @@ nodes:
 	fmt.Println("Kube-proxy patched! Guys how can I test this? To find out if it was really successful.")
 
 	// Generate the file kubeconfig.conf on the artifacts directory
-	cmd_string = kind + " get kubeconfig --internal --name " + clusterName +" > " + artifactsDirectory + "/kubeconfig.conf"
-	cmd = exec.Command("bash", "-c", cmd_string)
+	cmdString = kind + " get kubeconfig --internal --name " + clusterName +" > " + artifactsDirectory + "/kubeconfig.conf"
+	cmd = exec.Command("bash", "-c", cmdString)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Failed to create the file kubeconfig.conf.\n", err)
 	}
 
 	// Generate the file KubeconfigTests on the artifacts directory
-	cmd_string = kind + " get kubeconfig --name " + clusterName +" > " + artifactsDirectory + "/" + KubeconfigTests
-	cmd = exec.Command("bash", "-c", cmd_string)
+	cmdString = kind + " get kubeconfig --name " + clusterName +" > " + artifactsDirectory + "/" + KubeconfigTests
+	cmd = exec.Command("bash", "-c", cmdString)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Failed to create the file KubeconfigTests.\n", err)
@@ -565,7 +565,7 @@ nodes:
 // waitUntilClusterIsReady wait pods with selector k8s-app=kube-dns be ready and operational.
 func waitUntilClusterIsReady(clusterName, binDir string, ciMode bool) {
 
-	k8s_context := "kind-" + clusterName
+	k8sContext := "kind-" + clusterName
 	kubectl := binDir + "/kubectl"
 
 	_, err := os.Stat(binDir)
@@ -578,21 +578,21 @@ func waitUntilClusterIsReady(clusterName, binDir string, ciMode bool) {
 		log.Fatal(err)
 	}
 
-	cmd_string := "kubectl --context " + k8s_context + " wait --for=condition=ready pods --namespace=" + Namespace + " --selector k8s-app=kube-dns 1> /dev/null"
-	cmd := exec.Command("bash", "-c", cmd_string)
+	cmdString := "kubectl --context " + k8sContext + " wait --for=condition=ready pods --namespace=" + Namespace + " --selector k8s-app=kube-dns 1> /dev/null"
+	cmd := exec.Command("bash", "-c", cmdString)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatal(err)
 	}
 	
 	if ciMode == true {
-		cmd = exec.Command("kubectl", "--context", k8s_context, "get", "nodes", "-o", "wide")
+		cmd = exec.Command("kubectl", "--context", k8sContext, "get", "nodes", "-o", "wide")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal("Unable to show nodes.", err)
 		}
 
-		cmd = exec.Command("kubectl", "--context", k8s_context, "get", "pods", "--all-namespaces")
+		cmd = exec.Command("kubectl", "--context", k8sContext, "get", "pods", "--all-namespaces")
 		err = cmd.Run()
 		if err != nil {
 			log.Fatal("Error getting pods from all namespaces.", err)
@@ -608,13 +608,13 @@ func waitUntilClusterIsReady(clusterName, binDir string, ciMode bool) {
 //   - deploy kpng from the template generated
 func installKpng(clusterName, binDir string) {
 
-	k8s_context := "kind-" + clusterName
+	k8sContext := "kind-" + clusterName
 	kubectl 	:= binDir + "/kubectl"
 	kind		:= binDir + "/kind"
 	
 	artifactsDirectory := os.Getenv("E2E_ARTIFACTS")
-	E2E_BACKEND := os.Getenv("E2E_BACKEND")
-	E2E_DEPLOYMENT_MODEL := os.Getenv("E2E_DEPLOYMENT_MODEL")
+	e2eBackend := os.Getenv("E2E_BACKEND")
+	e2eDeploymentModel := os.Getenv("E2E_DEPLOYMENT_MODEL")
 
 	_, err := os.Stat(binDir)
 	if err !=nil && os.IsNotExist(err) {
@@ -627,7 +627,7 @@ func installKpng(clusterName, binDir string) {
 	}
 
 	// Remove existing kube-proxy
-	cmd := exec.Command(kubectl, "--context", k8s_context, "delete", "--namespace", Namespace, "daemonset.apps/kube-proxy")
+	cmd := exec.Command(kubectl, "--context", k8sContext, "delete", "--namespace", Namespace, "daemonset.apps/kube-proxy")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Cannot delete delete daemonset.apps kube-proxy\n", err)
@@ -644,21 +644,21 @@ func installKpng(clusterName, binDir string) {
 	fmt.Println("Loaded " + KpngImageTagName + " container image.")
 
 	// Create service account, clusterbinding and configmap for kpng
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "serviceaccount", "--namespace", Namespace, ServiceAccountName)
+	cmd = exec.Command(kubectl, "--context", k8sContext, "create", "serviceaccount", "--namespace", Namespace, ServiceAccountName)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error creating serviceaccount %s.\n", ServiceAccountName, err)
 	}
 	fmt.Println("Created service account", ServiceAccountName)
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "clusterrolebinding", ClusterRoleBindingName, "--clusterrole", ClusterRoleName, "--serviceaccount", Namespace + ":"+ ServiceAccountName)
+	cmd = exec.Command(kubectl, "--context", k8sContext, "create", "clusterrolebinding", ClusterRoleBindingName, "--clusterrole", ClusterRoleName, "--serviceaccount", Namespace + ":"+ ServiceAccountName)
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error creating clusterrolebinding %s.\n", ClusterRoleBindingName, err)
 	}
 	fmt.Println("Created clusterrolebinding", ClusterRoleBindingName)
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "configmap", ConfigMapName, "--namespace", Namespace, "--from-file", artifactsDirectory + "/kubeconfig.conf")
+	cmd = exec.Command(kubectl, "--context", k8sContext, "create", "configmap", ConfigMapName, "--namespace", Namespace, "--from-file", artifactsDirectory + "/kubeconfig.conf")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error creating configmap", ConfigMapName)
@@ -666,45 +666,45 @@ func installKpng(clusterName, binDir string) {
 	fmt.Println("Created configmap", ConfigMapName)
 
 	// Deploy kpng from the template generated
-	E2E_SERVER_ARGS := "'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-api', '--listen=unix:///k8s/proxy.sock'"
-    E2E_BACKEND_ARGS := "'local', '--api=" + KpngServerAddress + "', 'to-" + E2E_BACKEND + "', '--v=" + KpngDebugLevel + "'"
+	e2eServerArgs := "'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-api', '--listen=unix:///k8s/proxy.sock'"
+    e2eBackendArgs := "'local', '--api=" + KpngServerAddress + "', 'to-" + e2eBackend + "', '--v=" + KpngDebugLevel + "'"
 
-	if E2E_DEPLOYMENT_MODEL == "single-process-per-node" {
-		E2E_BACKEND_ARGS="'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-local', 'to-" + E2E_BACKEND + "', '--v=" + KpngDebugLevel + "'"
+	if e2eDeploymentModel == "single-process-per-node" {
+		e2eBackendArgs="'kube', '--kubeconfig=/var/lib/kpng/kubeconfig.conf', 'to-local', 'to-" + e2eBackend + "', '--v=" + KpngDebugLevel + "'"
 	} 
 
-	E2E_SERVER_ARGS = "[" + E2E_SERVER_ARGS + "]"
-	E2E_BACKEND_ARGS = "[" + E2E_BACKEND_ARGS + "]"
+	e2eServerArgs = "[" + e2eServerArgs + "]"
+	e2eBackendArgs = "[" + e2eBackendArgs + "]"
 
 	// Setting vars for generate the kpng deployment based on template
 	_ = os.Setenv("kpng_image", KpngImageTagName) 
     _ = os.Setenv("image_pull_policy", "IfNotPresent") 
-    _ = os.Setenv("backend", E2E_BACKEND) 
+    _ = os.Setenv("backend", e2eBackend) 
     _ = os.Setenv("config_map_name", ConfigMapName) 
     _ = os.Setenv("service_account_name", ServiceAccountName) 
     _ = os.Setenv("namespace", Namespace) 
-    _ = os.Setenv("e2e_backend_args", E2E_BACKEND_ARGS)
-    _ = os.Setenv("deployment_model", E2E_DEPLOYMENT_MODEL)
-    _ = os.Setenv("e2e_server_args", E2E_SERVER_ARGS)
+    _ = os.Setenv("e2e_backend_args", e2eBackendArgs)
+    _ = os.Setenv("deployment_model", e2eDeploymentModel)
+    _ = os.Setenv("e2e_server_args", e2eServerArgs)
 
-	// TODO: Change kpngDir to SCRIPT_DIR
-	//go run "${SCRIPT_DIR}"/kpng-ds-yaml-gen.go "${SCRIPT_DIR}"/kpng-deployment-ds-template.txt  "${artifactsDirectory}"/kpng-deployment-ds.yaml	
+	// TODO: Change kpngDir to scriptDir
+	//go run "${scriptDir}"/kpng-ds-yaml-gen.go "${scriptDir}"/kpng-deployment-ds-template.txt  "${artifactsDirectory}"/kpng-deployment-ds.yaml	
 	//ifErrorExit "error generating kpng deployment YAML"
-	SCRIPT_DIR := kpngDir + "/hack"
+	scriptDir := kpngDir + "/hack"
 
-	cmd = exec.Command("go", "run", SCRIPT_DIR + "/kpng-ds-yaml-gen.go", SCRIPT_DIR + "/kpng-deployment-ds-template.txt", artifactsDirectory + "/kpng-deployment-ds.yaml")
+	cmd = exec.Command("go", "run", scriptDir + "/kpng-ds-yaml-gen.go", scriptDir + "/kpng-deployment-ds-template.txt", artifactsDirectory + "/kpng-deployment-ds.yaml")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error generating kpng deployment YAML.", err)
 	}
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "create", "-f", artifactsDirectory + "/kpng-deployment-ds.yaml")
+	cmd = exec.Command(kubectl, "--context", k8sContext, "create", "-f", artifactsDirectory + "/kpng-deployment-ds.yaml")
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Error creating kpng deployment \n", err)
 	}
 
-	cmd = exec.Command(kubectl, "--context", k8s_context, "--namespace", Namespace, "rollout", "status", "daemonset", "kpng", "-w", "--request-timeout", "3m")	
+	cmd = exec.Command(kubectl, "--context", k8sContext, "--namespace", Namespace, "rollout", "status", "daemonset", "kpng", "-w", "--request-timeout", "3m")	
 	err = cmd.Run()
 	if err != nil {
 		log.Fatalf("Timeout waiting kpng rollout\n", err)
@@ -719,7 +719,7 @@ func runTests(e2eDir, binDir string, parallelGinkgoTests bool, ipFamily, backend
 
 	artifactsDirectory := e2eDir + "/artifacts"
 	ginkgo := binDir + "/ginkgo"
-	e2e_test := binDir + "/e2e.test"
+	e2eTest := binDir + "/e2e.test"
 
 	_, err := os.Stat(artifactsDirectory + "/" + KubeconfigTests)
 	if err != nil && os.IsNotExist(err) {
@@ -739,22 +739,22 @@ func runTests(e2eDir, binDir string, parallelGinkgoTests bool, ipFamily, backend
 	}
 
 	// Ginkgo regexes
-	ginkgo_skip := GinkgoSkipTests
-	ginkgo_focus := ""
+	ginkgoSkip := GinkgoSkipTests
+	ginkgoFocus := ""
 	if strings.TrimSpace(GinkgoFocus) == "" {
-		ginkgo_focus = "\\[Conformance\\]"
+		ginkgoFocus = "\\[Conformance\\]"
 	} else {
-		ginkgo_focus = GinkgoFocus
+		ginkgoFocus = GinkgoFocus
 	}
 	
-	var skip_set_name,  skip_set_ref string
+	var skipSetName, skipSetRef string
 
 	if includeSpecificFailedTests == false {
 	// Find ip_type and backend specific skip sets	
-		skip_set_name = "GINKGO_SKIP_" + ipFamily + "_" + backend + "_TEST"
-		skip_set_ref = skip_set_name
-		if len(strings.TrimSpace(skip_set_ref)) > 0 {
-			ginkgo_skip = ginkgo_skip + "|" + skip_set_ref
+		skipSetName = "GINKGO_SKIP_" + ipFamily + "_" + backend + "_TEST"
+		skipSetRef = skipSetName
+		if len(strings.TrimSpace(skipSetRef)) > 0 {
+			ginkgoSkip = ginkgoSkip + "|" + skipSetRef
 		}	
 	}
 
@@ -765,7 +765,7 @@ func runTests(e2eDir, binDir string, parallelGinkgoTests bool, ipFamily, backend
 	_ = os.Setenv("KUBE_CONTAINER_RUNTIME_ENDPOINT", "unix:///run/containerd/containerd.sock")
 	_ = os.Setenv("KUBE_CONTAINER_RUNTIME_NAME", "containerd")
 
-	cmd := exec.Command(ginkgo, "--nodes", strconv.Itoa(GinkgoNumberOfNodes), "--focus", ginkgo_focus, "--skip", ginkgo_skip, e2e_test, 
+	cmd := exec.Command(ginkgo, "--nodes", strconv.Itoa(GinkgoNumberOfNodes), "--focus", ginkgoFocus, "--skip", ginkgoSkip, e2eTest, 
 		"--kubeconfig", artifactsDirectory + "/" + KubeconfigTests, "--provider", GinkgoProvider, "--dump-logs-on-failure", strconv.FormatBool(GinkgoDumpLogsOnFailure), 
 	 	"--report-dir", GinkgoReportDir, "--disable-log-dump", strconv.FormatBool(GinkgoDisableLogDump))
 	err = cmd.Run()
@@ -843,7 +843,7 @@ func main() {
 
 	wd, err := os.Getwd()
 	ifErrorExit(err)
-	base_dir := wd //How can I have this variable as a constant??? 
+	baseDir := wd //How can I have this variable as a constant??? 
 	kpngDir = path.Dir(wd)
 
 
@@ -858,8 +858,8 @@ func main() {
 
 	// Get the OS
 	var buffer bytes.Buffer 
-	cmd_string := "uname | tr '[:upper:]' '[:lower:]'"
-	cmd := exec.Command("bash", "-c", cmd_string) // I need to better understand the -c option! And also try to implement it using Cmd.StdinPipe
+	cmdString := "uname | tr '[:upper:]' '[:lower:]'"
+	cmd := exec.Command("bash", "-c", cmdString) // I need to better understand the -c option! And also try to implement it using Cmd.StdinPipe
 	cmd.Stdout = &buffer
 	err = cmd.Run()
 	ifErrorExit(err)
@@ -867,22 +867,22 @@ func main() {
 
 
 	// Get the path to the Dockerfile
-	cmd = exec.Command("dirname", base_dir)
+	cmd = exec.Command("dirname", baseDir)
 	buffer.Reset()
 	cmd.Stdout = &buffer
 	err = cmd.Run()
 	ifErrorExit(err)
 	dockerfile = strings.TrimSpace(buffer.String()) + "/Dockerfile"
 
-	installBinaries(binDir, KubernetesVersion, OS, base_dir)
+	installBinaries(binDir, KubernetesVersion, OS, baseDir)
 	prepareContainer(dockerfile, ciMode)
 
-	tmp_suffix := ""
+	tmpSuffix := ""
 	if cluster_count == 1 {
 		if len(suffix) > 0 {
-			tmp_suffix = "-" + suffix
+			tmpSuffix = "-" + suffix
 		}
-		setE2eDir(e2eDir + tmp_suffix)
+		setE2eDir(e2eDir + tmpSuffix)
 	}
 
 	createInfrastructureAndRunTests(e2eDir, ipFamily, backend, binDir, suffix, developerMode, ciMode, deploymentModel, exportMetrics, includeSpecificFailedTests)

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -13,7 +13,7 @@ import (
 const (
 	KIND_VERSION="v0.17.0"
 	K8S_VERSION="v1.25.3"
-
+	
 )
 
 func if_error_exit(error_msg error) {
@@ -361,8 +361,45 @@ func install_binaries(bin_directory, k8s_version, operating_system, base_dir_pat
 	setup_bpf2go(bin_directory)
 }
 
+func detect_container_engine(container_engine string) {
+	///////////////////////////////////////////////////////////////////////////
+    // Description:                                                           
+    // Detect Container Engine, by default it is docker but developers might   
+    // use real alternatives like podman. The project welcome both.            
+    //                                                                         
+    // Arguments:                                                              
+    //   None
+	///////////////////////////////////////////////////////////////////////////                                                                  	
+	// If docker is not available, let's check if podman exists
+	cmd := exec.Command(container_engine) 
+	err := cmd.Run()
+	if err != nil {
+		container_engine = "podman"
+		cmd = exec.Command(container_engine, "--help")
+		err = cmd.Run() 
+		if err != nil {
+			fmt.Println("The e2e tests currently support docker and podman as the container engine. Please install either of them")
+			os.Exit(1)
+		}
+	}
+	fmt.Println("Detected Container Engine:", container_engine)
+}
 
+func prepare_container() {
+	///////////////////////////////////////////////////////////////////////////
+	// Description:
+    // Prepare container  
+    //                                                      
+    // Arguments:
+    //   arg1: Path of dockerfile
+    //   arg2: ci_mode
+	///////////////////////////////////////////////////////////////////////////
 
+	CONTAINER_ENGINE := "docker"
+
+	detect_container_engine(CONTAINER_ENGINE)
+
+}
 
 
 func main() {
@@ -394,5 +431,6 @@ func main() {
 	OS := strings.TrimSpace(buffer.String())
 
 	install_binaries(bin_dir, K8S_VERSION, OS, base_dir)
+	prepare_container()
 
 }

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -131,6 +131,42 @@ func set_host_network_settings(ip_family string) {
 	}	
 }
 
+func verify_sysctl_setting(attribute string, value int) {
+	///////////////////////////////////////////////////////////////////////////
+	// Description:                                                            
+    // Verify that a sysctl attribute setting has a value                      
+    //                                                                         
+    // Arguments:                                                              
+    //   arg1: attribute                                                       
+    //   arg2: value                                                           
+	///////////////////////////////////////////////////////////////////////////
+
+	// Get the current value of the attribute and store it in the result variable
+	var buffer bytes.Buffer
+	cmd := exec.Command("sysctl", "-n", attribute)
+	cmd.Stdout = &buffer
+	err := cmd.Run()
+	if_error_exit(err)
+	result, err := strconv.Atoi(strings.TrimSpace(buffer.String()))
+
+	if value != result {
+		fmt.Printf("Failure: \"sysctl -n %s\" returned \"%d\", not \"%d\" as expected.\n", attribute, result, value)	
+		os.Exit(1)
+	}
+}
+
+func verify_host_network_settings(ip_family string) {
+	///////////////////////////////////////////////////////////////////////////
+	// Description:                                                            
+	// Verify hosts network settings                                           
+	//                                                                         
+	// Arguments:                                                              
+	//   arg1: ip_family                                                       
+	///////////////////////////////////////////////////////////////////////////
+
+	verify_sysctl_setting("net.ipv4.ip_forward", 1)
+} 
+
 func setup_kind(install_directory, operating_system string) {
 	///////////////////////////////////////////////////////////////////////////
 	// Description:                                                            
@@ -358,6 +394,5 @@ func main() {
 	OS := strings.TrimSpace(buffer.String())
 
 	install_binaries(bin_dir, K8S_VERSION, OS, base_dir)
-
 
 }

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"log"
 	"bytes"
@@ -22,7 +23,33 @@ func if_error_exit(error_msg error) {
 } 
 
 func add_to_path(directory string) {
+    // Description:                                                            #
+    // Add directory to path                                                   #
+    //                                                                         #
+    // Arguments:                                                              #
+    //   arg1:  directory                                                      #	
+	///////////////////////////////////////////////////////////////////////
 
+	_, err := os.Stat(directory)
+	if err != nil && os.IsNotExist(err) {
+		if_error_exit(err)
+	}
+
+	path := os.Getenv("PATH")
+	fmt.Println(path)
+
+	if !(strings.Contains(path, ":" + directory + ":")) && !(strings.Contains(path, ":" + directory)) {
+		fmt.Println(directory)
+		fmt.Println("Directory Not in the $PATH env! :(")
+		updated_path := path + ":" + directory
+		err = os.Setenv("PATH", updated_path)
+		//cmd :=exec.Command("export", updated_path)
+		//err = cmd.Run()
+		if_error_exit(err)
+		fmt.Println(os.Getenv("PATH"))
+		fmt.Println("Directory, NOW, is in the $PATH env! :)")
+	}
+	fmt.Println("Directory exist hooray :)")
 }
 
 func set_sysctl(attribute string, value int) {
@@ -61,13 +88,13 @@ func set_host_network_settings(ip_family string) {
 	//	arg1: ip_family
 	///////////////////////////////////////////////////////////////////////
 	set_sysctl("net.ipv4.ip_forward", 1)
-	if ip_family = "ipv6" {
+	if ip_family == "ipv6" {
 		//TODO 
 		fmt.Println("TODO :-)")
 	}	
 }
 
-func install_binaries(bin_directory string, k8s_version string, os string) {
+func install_binaries(bin_directory, k8s_version, operating_system, base_dir_path string, ) {
     
     // Description:
     // Copy binaries from the net to binaries directory
@@ -80,11 +107,13 @@ func install_binaries(bin_directory string, k8s_version string, os string) {
 	wd, err := os.Getwd()
 	if_error_exit(err)
 	
-	if wd != basename_dir {
-		err = os.Chdir(basename_dir)
-		if_error_exit
+	if wd != base_dir_path {
+		err = os.Chdir(base_dir_path)
+		if_error_exit(err)
 	}
-	os.MkdirAll() ...
+	err = os.MkdirAll(bin_directory, 0755) 
+
+	add_to_path(bin_directory)
 
 }
 
@@ -97,9 +126,9 @@ func main() {
 	var e2e_dir string = ""
 	var bin_dir string = ""	
 
-	wd, err := os.Getwd
+	wd, err := os.Getwd()
 	if_error_exit(err)
-	const basename_dir = wd
+	base_dir := wd //How can I have this variable as a constant??? 
 
 
 	if e2e_dir == "" {
@@ -111,9 +140,7 @@ func main() {
 		bin_dir = e2e_dir + "/bin"
 	}
 
-
-
-
+	install_binaries(bin_dir, "1.19", "linux", base_dir)
 
 
 }

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -125,31 +125,47 @@ func setup_kind(install_directory, operating_system string) {
 	}
 
 	_, err = os.Stat(install_directory + "/kind")
-	if err != nil && os.IsNotExist(err) {
+	if err == nil {
+		fmt.Println("The kind tool is already set in your system.")
+	} else if err != nil && os.IsNotExist(err) {
 		fmt.Println()
 		fmt.Println("Downloading kind ...")
-	}
 
-	tmp_file, err := os.CreateTemp("/tmp", "kind_setup")
-	if_error_exit(err)
-	defer os.Remove(tmp_file.Name()) // Clean up. QUESTION: As we will end up moving the temp file, is this necessary? 
-
-	url := "https://kind.sigs.k8s.io/dl/" + KIND_VERSION + "/kind-" + operating_system + "-amd64"
-	fmt.Printf("Temp filename: %s\n", tmp_file.Name())
-	cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())	
-	err = cmd.Run()
-	if_error_exit(err)
-	// TODO: Need to find out how to display, the curl ongoing download details, on the terminal
-
-
-	cmd = exec.Command("sudo", "mv", tmp_file.Name(), install_directory + "/kind")
-	_ = cmd.Run()
-	//if_error_exit(err) 
-	cmd = exec.Command("sudo", "chmod", "+rx", install_directory + "/kind")
-	_ = cmd.Run()
-	cmd = exec.Command("sudo", "chown", "root.root", install_directory + "/kind")
+		tmp_file, err := os.CreateTemp("/tmp", "kind_setup")
+		if_error_exit(err)
+		defer os.Remove(tmp_file.Name()) // Clean up. QUESTION: As we will end up moving the temp file, is this necessary? 
 	
-	fmt.Println("The kind tool is set.")
+		url := "https://kind.sigs.k8s.io/dl/" + KIND_VERSION + "/kind-" + operating_system + "-amd64"
+		fmt.Printf("Temp filename: %s\n", tmp_file.Name())
+		cmd := exec.Command("curl", "-L", url, "-o", tmp_file.Name())	
+		err = cmd.Run()
+		if_error_exit(err)
+		// TODO: Need to find out how to display, the curl ongoing download details, on the terminal
+	
+		cmd = exec.Command("sudo", "mv", tmp_file.Name(), install_directory + "/kind")
+		_ = cmd.Run()
+		//if_error_exit(err) 
+		cmd = exec.Command("sudo", "chmod", "+rx", install_directory + "/kind")
+		_ = cmd.Run()
+		cmd = exec.Command("sudo", "chown", "root.root", install_directory + "/kind")
+		
+		fmt.Println("The kind tool is set.")		
+	}
+}
+
+func setup_kubectl(install_directory, k8s_version, operating_system string) {
+    // Description:                                                            
+    // setup kubectl if not available in the system                            
+    //                                                                         
+    // Arguments:                                                              
+    //   arg1: installation directory, path to where kubectl will be installed 
+    //   arg2: Kubernetes version                                              
+    //   arg3: OS, name of the operating system                                
+	///////////////////////////////////////////////////////////////////////////
+
+
+
+	
 }
 
 func install_binaries(bin_directory, k8s_version, operating_system, base_dir_path string, ) {

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -75,6 +75,9 @@ func ifErrorExit(errorMsg error) {
 
 // commandExist check if a binary(cmdTest) exists. It returns True or False 
 func commandExist(cmdTest string) bool {
+	// Command is a Bash builtin command. 
+	// It execute a simple command or display information about commands.
+	// "command -v" print a description of COMMAND similar to the `type' builtin
 	cmdScript := "command -v " + cmdTest + " > /dev/null 2>&1"
 	cmd := exec.Command("bash", "-c", cmdScript)
 	err := cmd.Run()

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -29,7 +29,6 @@ func add_to_path(directory string) {
     // Arguments:                                                              #
     //   arg1:  directory                                                      #	
 	///////////////////////////////////////////////////////////////////////
-
 	_, err := os.Stat(directory)
 	if err != nil && os.IsNotExist(err) {
 		if_error_exit(err)
@@ -38,18 +37,29 @@ func add_to_path(directory string) {
 	path := os.Getenv("PATH")
 	fmt.Println(path)
 
-	if !(strings.Contains(path, ":" + directory + ":")) && !(strings.Contains(path, ":" + directory)) {
+	// Check if the directory path is in the $PATH env variable 
+	// I believe the package regexp can be used. Couldn't figure out the right pattern. For now 
+	// will use the following approach
+	// TODO(Maybe!): Check using the regexp package
+	path_set := strings.Split(path, ":") 
+	dir_path_exist := false
+	for _, s := range path_set {
+		if directory == s {
+			dir_path_exist = true
+			break
+		}
+	}
+
+	if !dir_path_exist {
 		fmt.Println(directory)
 		fmt.Println("Directory Not in the $PATH env! :(")
 		updated_path := path + ":" + directory
 		err = os.Setenv("PATH", updated_path)
-		//cmd :=exec.Command("export", updated_path)
-		//err = cmd.Run()
 		if_error_exit(err)
 		fmt.Println(os.Getenv("PATH"))
-		fmt.Println("Directory, NOW, is in the $PATH env! :)")
+		fmt.Println("Directory, NOW, is in the $PATH env! hooray:)")
 	}
-	fmt.Println("Directory exist hooray :)")
+
 }
 
 func set_sysctl(attribute string, value int) {

--- a/hack/test_e2e.go
+++ b/hack/test_e2e.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"log"
+	"bytes"
+	"strconv"
+	"strings"
+) 
+
+func if_error_exit(error_msg error) {
+    // Description:
+    // Validate if previous command failed and show an error msg (if provided) 
+    //
+	// Arguments:
+	// $1 - error message if not provided, it will just exit
+	///////////////////////////////////////////////////////////////////////////
+	if error_msg != nil {
+		log.Fatal(error_msg)
+	}
+} 
+
+func set_sysctl(attribute string, value int) {
+    // Description:
+    // Set a sysctl attribute to value
+    //                                         
+    // Arguments:
+    //   arg1: attribute
+    //   arg2: value
+	///////////////////////////////////////////////////////////////
+	var buffer bytes.Buffer
+	cmd := exec.Command("sysct", "-n", attribute )
+	cmd.Stdout = &buffer
+	//result, err := cmd.Output() //cmd.Output() returns bytes. How to convert bytes to int?
+	err := cmd.Run()
+	if_error_exit(err)
+
+	result_str := strings.TrimSpace(buffer.String())
+	result_int, err := strconv.Atoi(result_str)
+	
+	fmt.Printf("Checking sysctls value: %d vs result: %d\n", value, result_int)
+	if value != result_int {
+		fmt.Printf("Setting: \"sysctl -w %s=%d\"\n", attribute, value)
+		variable_value := attribute + "=" + strconv.Itoa(value)
+		cmd = exec.Command("sudo", "sysctl", "-w", variable_value)
+		err = cmd.Run()
+		if_error_exit(err)
+	}
+}
+
+func set_host_network_settings(ip_family string) {
+	// Description: 
+	// Prepare hosts network settings 
+	//
+	// Arguments: 
+	//	arg1: ip_family
+
+
+}
+
+func main() {
+	fmt.Println("Verify Host Networking Settings")
+	set_sysctl("net.ipv4.ip_forward", 1)
+
+}


### PR DESCRIPTION
This PR is aimed at the issue #430. 
It focus, initially, on the implementation of the e2e_test in go. 
I decided to start by aiming at a program that will work on this conditions: **ip_family=ipv4, backend=iptables, cluster_count=1**

Studying the current `test_e2e.sh` script I identified the main functions required to have a working `test_e2e.go` program. And documented it in [here](https://docs.google.com/document/d/1fanr95mp9Sc-wh9Ss0PFqu9yqUA6tdA2fRxUWq3lmmY/edit?usp=sharing). Please check the MILESTONES on the document, and let me know if there is something missing. 

So basically my current approach is to implement each identified function, in **go**. 
On this PR I have implemented the first 5 functions: `Info_error_exit, set_sysctl, set_host_networking_settings, add_to_path, setup_kind`

@jayunit100 , @rajaskakodkar please comments. Let me know if this is the way to go.