### PR TITLE
Improvements in e2e_tests

### DIFF
--- a/hack/test_e2e.sh
+++ b/hack/test_e2e.sh
@@ -14,6 +14,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source "${SCRIPT_DIR}"/utils.sh
+source "${SCRIPT_DIR}"/common.sh
+source "${SCRIPT_DIR}"/test_skip_list.sh
+
 if [[ $OSTYPE == 'darwin'* ]]; then
   info_message "The kpng build script only works on linux... Exiting now!"
   exit 1
@@ -28,7 +35,6 @@ shopt -s expand_aliases
 CONTAINER_ENGINE="docker"
 KPNG_IMAGE_TAG_NAME="kpng:test"
 KUBECONFIG_TESTS="kubeconfig_tests.conf"
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # ginkgo
 GINKGO_NUMBER_OF_NODES=25
@@ -38,10 +44,6 @@ GINKGO_REPORT_DIR="artifacts/reports"
 GINKGO_DUMP_LOGS_ON_FAILURE=false
 GINKGO_DISABLE_LOG_DUMP=true
 GINKGO_PROVIDER="local"
-
-source "${SCRIPT_DIR}"/utils.sh
-source "${SCRIPT_DIR}"/common.sh
-source "${SCRIPT_DIR}"/test_skip_list.sh
 
 function if_error_warning {
     ###########################################################################
@@ -53,8 +55,8 @@ function if_error_warning {
     ###########################################################################
     if [ "$?" != "0" ]; then
         if [ -n "$1" ]; then
-            RED="\e[91m"
-            ENDCOLOR="\e[0m"
+            RED="\033[91m"
+            ENDCOLOR="\033[0m"
             echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
         fi
     fi
@@ -79,9 +81,9 @@ function result_message {
         echo "result_message() requires a message"
         exit 1
     fi
-    RED="\e[91m"
-    GREEN="\e[92m"    
-    ENDCOLOR="\e[0m"
+    RED="\033[91m"
+    GREEN="\033[92m"    
+    ENDCOLOR="\033[0m"
 
     if [ "${result}" == "0" ] ; then
 	echo -e "${GREEN}[SUCCESS!] ${message} succeded!!! ${ENDCOLOR}"

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -24,8 +24,8 @@ function if_error_exit {
     ###########################################################################
     if [ "$?" != "0" ]; then
         if [ -n "$1" ]; then
-            RED="\e[91m"
-            ENDCOLOR="\e[0m"
+            RED="\033[91m"
+            ENDCOLOR="\033[0m"
             echo -e "[ ${RED}FAILED${ENDCOLOR} ] ${1}"
         fi
         exit 1
@@ -44,8 +44,8 @@ function pass_message {
         echo "pass_message() requires a message"
         exit 1
     fi
-    GREEN="\e[92m"
-    ENDCOLOR="\e[0m"
+    GREEN="\033[92m"
+    ENDCOLOR="\033[0m"
     echo -e "[ ${GREEN}PASSED${ENDCOLOR} ] ${1}"
 }
 
@@ -61,8 +61,8 @@ function info_message {
         echo "info_message() requires a message"
         exit 1
     fi
-    BLUE="\e[94m"
-    ENDCOLOR="\e[0m"
+    BLUE="\033[94m"
+    ENDCOLOR="\033[0m"
     echo -e "[ ${BLUE}INFO${ENDCOLOR} ] ${1}"
 }
 
@@ -92,7 +92,7 @@ function add_to_path {
 command_exists() {
     ###########################################################################
     # Description:                                                            #
-    # Checkt if a binary exists                                               #
+    # Checks if a binary exists                                               #
     #                                                                         #
     # Arguments:                                                              #
     #   arg1: binary name                                                     #


### PR DESCRIPTION
- move all 'source'ing to the beginning. Fixes the issue of 'info_message' being not available since `utils.sh` is not sourced at the point it's used
- change control sequence for terminal colors from `\e` to `\033`. This has wider support. `\e` is breaking on atleast some Macs