### PR TITLE
expose metrics endpoint from within kpng

### DIFF
--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -13,8 +13,32 @@ nodes:
         kind: InitConfiguration
         nodeRegistration:
           kubeletExtraArgs:
-            node-labels: "kube-proxy=kpng"
+            node-labels: "kube-proxy=kpng,ingress-ready=true"
             authorization-mode: "AlwaysAllow"
+      - |
+        kind: ClusterConfiguration
+        metadata:
+          name: config
+        etcd:
+          local:
+            extraArgs:
+              "listen-metrics-urls": "http://0.0.0.0:2381"
+        apiServer:
+          extraArgs:
+            "v": "3"
+        scheduler:
+          extraArgs:
+            "v": "3"
+        controllerManager:
+          extraArgs:
+            "v": "3"
+    extraPortMappings:
+    - containerPort: 80
+      hostPort: 80
+      protocol: TCP
+    - containerPort: 443
+      hostPort: 443
+      protocol: TCP
   - role: worker
     kubeadmConfigPatches:
       - |

--- a/hack/kpng-deployment-ds-template.txt
+++ b/hack/kpng-deployment-ds-template.txt
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         app: kpng
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9099"
     spec:
       # to enable progressive deployment on existing cluster you can use node labels:
       #nodeSelector:
@@ -80,6 +83,9 @@ spec:
         - name: GOLANG_PROTOBUF_REGISTRATION_CONFLICT
           value: warn
         name: kpng
+        ports:
+        - containerPort: 9099
+          protocol: TCP
         volumeMounts:
         - name: empty
           mountPath: /k8s

--- a/hack/metrics/README.md
+++ b/hack/metrics/README.md
@@ -1,0 +1,31 @@
+# Metrics
+
+## What is deployed
+
+Prometheus master
+
+Grafana
+
+Nginx ingress controller
+
+## How to use
+
+Create an /etc/hosts entry on your dev machine:
+
+```
+127.0.0.1 chart-example.local
+```
+
+Create a local cluster with metrics enabled:
+
+```
+cd kpng/hack
+
+DEPLOY_PROMETHEUS=true ./kpng-local-up.sh
+```
+
+Open Grafana in your web browser:
+
+ - http://chart-example.local/login 
+   - creds: admin / admin
+ - take a look at a dashboard: http://chart-example.local/d/abcdefgh/nginx-ingress-controller?orgId=1

--- a/hack/metrics/deploy.sh
+++ b/hack/metrics/deploy.sh
@@ -12,7 +12,7 @@ METRICS_NS=${METRICS_NS:-"metrics"}
 #   these images down from remote registries
 
 images=(
-  "k8s.gcr.io/ingress-nginx/controller:v1.1.1@sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de"
+  "k8s.gcr.io/ingress-nginx/controller:v1.1.1"
   "grafana/grafana:8.3.4"
   "quay.io/kiwigrid/k8s-sidecar:1.15.1"
   "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0"

--- a/hack/metrics/nginx-values.yaml
+++ b/hack/metrics/nginx-values.yaml
@@ -1,6 +1,9 @@
 controller:
 
   admissionWebhooks:
+    # disable this because kube api-server blows up when creating an ingress rule
+    #   probably because of the special cluster config
+    enabled: false
     patch:
       image:
         digest: ""

--- a/hack/metrics/nginx-values.yaml
+++ b/hack/metrics/nginx-values.yaml
@@ -10,6 +10,14 @@ controller:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
+  
+  nodeSelector:
+    ingress-ready: "true"
 
   service:
     type: NodePort
+  
+  tolerations:
+   - key: "node-role.kubernetes.io/control-plane"
+     operator: "Exists"
+     effect: "NoSchedule"

--- a/hack/metrics/nginx-values.yaml
+++ b/hack/metrics/nginx-values.yaml
@@ -1,5 +1,10 @@
 controller:
 
+  admissionWebhooks:
+    patch:
+      image:
+        digest: ""
+
   hostPort:
     enabled: true
 
@@ -10,6 +15,11 @@ controller:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
+  
+  image:
+    # repository: "k8s.gcr.io/ingress-nginx/controller:v1.1.1"
+    # tag: "v1.7.0"
+    digest: ""
   
   nodeSelector:
     ingress-ready: "true"


### PR DESCRIPTION
# What

Sets up prometheus server in kpng that can be scraped by prometheus master.

Sets up Grafana with prometheus as a data source.

Sets up a couple of default dashboards (for kube api server and nginx ingress controller).

Sets up an nginx ingress controller , so that Grafana can be accessed through ingress.

For some reason, the existing `--exposeMetrics` flag DOES NOT work => there seem to be problems with flag setup in the kpng cli.  Therefore, this adds a new function to set up the metrics server.

# How to use

See new hack/metrics/README.md
