### PR TITLE
Fixes flag parsing

### DIFF
--- a/cmd/kpng/a2s.go
+++ b/cmd/kpng/a2s.go
@@ -38,7 +38,7 @@ var (
 // api2storeCmd is gives a feature to KPNG which allows you to read data from a KPNG server
 // and write it to a backend.  It can be used if you dont want to watch the K8s API, but want
 // to send data from another KPNG instance down to a backend.
-func api2storeCmd() *cobra.Command {
+func api2storeCmd(ctx context.Context) *cobra.Command {
 	// API to * command
 	api2sCmd := &cobra.Command{
 		Use:   "api",
@@ -49,7 +49,6 @@ func api2storeCmd() *cobra.Command {
 	api2storeJob.BindFlags(flags)
 
 	store := proxystore.New()
-	ctx := setupGlobal()
 
 	run := func() {
 		api2storeCmdRun(ctx, store)
@@ -63,7 +62,6 @@ func api2storeCmd() *cobra.Command {
 
 // api2storeCmdRun kicks off the api2store job.
 func api2storeCmdRun(ctx context.Context, store *proxystore.Store) {
-	ctx = setupGlobal()
 	api2storeJob.Store = store
 	api2storeJob.Run(ctx)
 }

--- a/cmd/kpng/f2s.go
+++ b/cmd/kpng/f2s.go
@@ -34,7 +34,7 @@ var f2sInput string
 // a networking model easily and send it to a store (i.e. a backend) of your choosing.  Its commonly
 // used for local development against a known kubernetes networking statespace (see the example in the doc/)
 // folder of an input YAML that works with this command.
-func file2storeCmd() *cobra.Command {
+func file2storeCmd(ctx context.Context) *cobra.Command {
 	// file to * command
 	f2sCmd := &cobra.Command{
 		Use:   "file",
@@ -44,7 +44,6 @@ func file2storeCmd() *cobra.Command {
 	flags := f2sCmd.PersistentFlags()
 	flags.StringVarP(&f2sInput, "input", "i", "globalv1-state.yaml", "Input file for the globalv1-state")
 
-	ctx := setupGlobal()
 	store := proxystore.New()
 	run := func() {
 		file2storeCmdRun(ctx, store)

--- a/cmd/kpng/k2s.go
+++ b/cmd/kpng/k2s.go
@@ -49,7 +49,7 @@ var (
 
 // kube2storeCmd generates the kube-to-store command, which is the "normal" way to run KPNG,
 // wherein you read data in from kubernetes, and push it into a store (file, API, or local backend such as NFT).
-func kube2storeCmd() *cobra.Command {
+func kube2storeCmd(ctx context.Context) *cobra.Command {
 	// kube to * command
 	k2sCmd := &cobra.Command{
 		Use:   "kube",
@@ -63,7 +63,6 @@ func kube2storeCmd() *cobra.Command {
 	// k8sCfg is the configuration of how we interact w/ and watch the K8s APIServer
 	k8sCfg.BindFlags(k2sCmd.PersistentFlags())
 
-	ctx := setupGlobal()
 	store := proxystore.New()
 	run := func() {
 		kube2storeCmdRun(ctx, store)

--- a/cmd/kpng/local.go
+++ b/cmd/kpng/local.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kpng/client/localsink"
@@ -24,7 +26,7 @@ import (
 	"sigs.k8s.io/kpng/server/jobs/api2local"
 )
 
-func local2sinkCmd() *cobra.Command {
+func local2sinkCmd(ctx context.Context) *cobra.Command {
 	// local to * command
 	cmd := &cobra.Command{
 		Use:   "local",
@@ -37,7 +39,6 @@ func local2sinkCmd() *cobra.Command {
 	job.BindFlags(flags)
 
 	cmd.AddCommand(builder.LocalCmds(func(sink localsink.Sink) (err error) {
-		ctx := setupGlobal()
 		job.Sink = sink
 		job.Run(ctx)
 		return

--- a/cmd/kpng/main.go
+++ b/cmd/kpng/main.go
@@ -49,6 +49,8 @@ func main() {
 	cmd := cobra.Command{
 		Use: "kpng",
 	}
+	// parse command line flags
+	flag.Parse()
 
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 

--- a/cmd/kpng/main.go
+++ b/cmd/kpng/main.go
@@ -53,12 +53,12 @@ func main() {
 	flag.Parse()
 
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-
+	ctx := setupGlobal()
 	cmd.AddCommand(
-		kube2storeCmd(), // no-op?
-		file2storeCmd(),
-		api2storeCmd(),
-		local2sinkCmd(),
+		kube2storeCmd(ctx), // no-op?
+		file2storeCmd(ctx),
+		api2storeCmd(ctx),
+		local2sinkCmd(ctx),
 		versionCmd(),
 	)
 


### PR DESCRIPTION
### What kind of PR is this?
bug fix for command line parsing in cmd/kpng/*.go

### Why this PR is needed / What this PR do?
The main file was missing flag.Parse() command which reads in the flags into the respective variables.

### Which issue(s) this PR fixes?

Fixes #481 

### Additional information about this PR

