### PR TITLE
Set go version on github actions from gowork file

### DIFF
--- a/.github/workflows/backend-build.yml
+++ b/.github/workflows/backend-build.yml
@@ -13,10 +13,13 @@ jobs:
     name: setup
     runs-on: ubuntu-latest
     steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
     - name: setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.19'
+        go-version-file: go.work
 
   iptables:
     name: build backend package iptables
@@ -25,7 +28,7 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v2
-    
+
     - name: build backends/iptables
       run: ./hack/test_backend_build.sh iptables
 
@@ -36,7 +39,7 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v2
-    
+
     - name: build backends/ipvs-as-sink
       run: ./hack/test_backend_build.sh ipvs
 
@@ -58,18 +61,18 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v2
-    
+
     - name: build backends/nft
       run: ./hack/test_backend_build.sh nft
 
-  ebpf: 
+  ebpf:
     name: build backend package ebpf
     needs: setup
     runs-on: ubuntu-latest
     steps:
     - name: checkout
       uses: actions/checkout@v2
-    
+
     - name: build backends/ebpf
       run: ./hack/test_backend_build.sh ebpf
 
@@ -83,4 +86,3 @@ jobs:
 
     - name: build backends/userspacelin
       run: ./hack/test_backend_build.sh userspacelin
-

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -7,18 +7,17 @@ on:
     branches:
       - master
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   setup:
     name: setup
     runs-on: ubuntu-latest
     steps:
+   - name: checkout
+      uses: actions/checkout@v2
     - name: setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.work
       id: go
 
     - name: Install dependencies
@@ -36,7 +35,7 @@ jobs:
       matrix:
         ipFamily: ["ipv4", "ipv6", "dual"]
         backend: ["iptables", "nft", "ipvs", "ipvsfullstate", "ebpf", "userspacelin"]
-        exclude: 
+        exclude:
           - ipFamily: "ipv6"
             backend: "ebpf"
           - ipFamily: "dual"
@@ -54,14 +53,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: setup ebpf backend dependencies
-      run: | 
-        if [[ ${{ env.BACKEND }} == "ebpf" ]]; then 
+      run: |
+        if [[ ${{ env.BACKEND }} == "ebpf" ]]; then
           export GOBIN=$(go env GOPATH)/bin
           export PATH=$PATH:$GOBIN
           echo "PATH=$PATH" >> $GITHUB_ENV
           go install github.com/cilium/ebpf/cmd/bpf2go@v0.9.2
           sudo apt-get install -y clang llvm libelf-dev libpcap-dev gcc-multilib build-essential
-        fi 
+        fi
 
     - name: run e2e tests
       run: ./hack/test_e2e.sh -i ${{ env.IP_FAMILY }} -b ${{ env.BACKEND }} -c -n 1 -S

--- a/.github/workflows/local-up-kpng.yaml
+++ b/.github/workflows/local-up-kpng.yaml
@@ -7,18 +7,18 @@ on:
     branches:
       - master
 
-env:
-  GO_VERSION: "1.19"
-
 jobs:
   setup:
     name: setup
     runs-on: ubuntu-latest
     steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
     - name: setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.work
       id: go
 
     - name: Install dependencies
@@ -35,6 +35,5 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
 
-    - name: KPNG local up 
+    - name: KPNG local up
       run: ./hack/kpng-local-up.sh
-

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,10 +13,12 @@ jobs:
     name: run unit tests
     runs-on: ubuntu-latest
     steps:
+    - name: checkout
+      uses: actions/checkout@v2
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.19'
+        go-version-file: go.work
         stable: 'false'
 
     - name: Install dependencies

--- a/.github/workflows/vet-code.yml
+++ b/.github/workflows/vet-code.yml
@@ -13,10 +13,12 @@ jobs:
     name: Run gofmt verify
     runs-on: ubuntu-latest
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+        go-version-file: go.work
           stable: 'false'
 
       - name: Install dependencies


### PR DESCRIPTION
### What kind of PR is this?
<!-- Add somethings like is it a Bug / Documentation / Feature -->
Set go version on GitHub actions from `go.work` file.

### Why this PR is needed / What this PR do?
<!-- Explain in brief about what you have changed and how it is helpful.-->
[actions/setup-go](https://github.com/actions/setup-go) can retrieve the version of go used in the repository from the go.work file.
It reduces to lines that need rewriting when updating the go version.

### Additional information about this PR
- https://github.com/actions/setup-go/blob/30c39bfe0c7338d0d8e99486938f1066b2f92108/README.md#getting-go-version-from-the-gomod-file
