### PR TITLE
apt-get update before installing ebpf's backend dependencies

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -58,7 +58,7 @@ jobs:
           export PATH=$PATH:$GOBIN
           echo "PATH=$PATH" >> $GITHUB_ENV
           go install github.com/cilium/ebpf/cmd/bpf2go@v0.9.2
-          sudo apt-get install -y clang llvm libelf-dev libpcap-dev gcc-multilib build-essential
+          sudo apt-get update && sudo apt-get install -y clang llvm libelf-dev libpcap-dev gcc-multilib build-essential
         fi
 
     - name: initialize ipvs module via ipvsadm


### PR DESCRIPTION
### What kind of PR is this?
It fixes the eBPF dependency setup step in the e2e_test workflow.

### Why this PR is needed / What this PR do?
As per @aroradaman [comment](https://github.com/kubernetes-sigs/kpng/pull/506#issuecomment-1561844221), it looks like the current pipeline is not able to find and download **gcc-multilib**. A simple `apt-get update` should theoretically solve this issue. 


