### PR TITLE
Load ipvs modules before enabling conntrack

### DIFF
--- a/backends/ipvs/internal/ipvs/setup.go
+++ b/backends/ipvs/internal/ipvs/setup.go
@@ -112,6 +112,11 @@ func initializeKernelConfig(kernelHandler KernelHandler) error {
 		klog.Info("Missing br-netfilter module or unset sysctl br-nf-call-iptables, proxy may not work as intended")
 	}
 
+	_, err := kernelHandler.GetModules()
+	if err != nil {
+		return err
+	}
+
 	// Set the conntrack sysctl we need for
 	if err := EnsureSysctl(sysctl, sysctlVSConnTrack, 1); err != nil {
 		return err

--- a/backends/ipvs/internal/ipvs/util.go
+++ b/backends/ipvs/internal/ipvs/util.go
@@ -51,7 +51,7 @@ type procSysctl struct {
 
 // GetSysctl returns the value for the specified sysctl setting
 func (*procSysctl) GetSysctl(sysctl string) (int, error) {
-	data, err := ioutil.ReadFile(path.Join(sysctlBase, sysctl))
+	data, err := os.ReadFile(path.Join(sysctlBase, sysctl))
 	if err != nil {
 		return -1, err
 	}
@@ -64,7 +64,7 @@ func (*procSysctl) GetSysctl(sysctl string) (int, error) {
 
 // SetSysctl modifies the specified sysctl flag to the new value
 func (*procSysctl) SetSysctl(sysctl string, newVal int) error {
-	return ioutil.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0640)
+	return os.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0640)
 }
 
 // EnsureSysctl sets a kernel sysctl to a given numeric value.

--- a/backends/ipvs/setup.go
+++ b/backends/ipvs/setup.go
@@ -40,7 +40,7 @@ func (b *backend) Setup() {
 	// right now it's a No-Op, will shift ipset initialization there
 	err = controller.ipsetsManager.Setup()
 	if err != nil {
-		klog.Fatal("unable to initialize ipvs manager", "error", err)
+		klog.Fatal("unable to initialize ipsets manager", "error", err)
 	}
 
 	// initialize ip sets


### PR DESCRIPTION
### What kind of PR is this?
Bugfix

### Why this PR is needed / What this PR do?
This PR loads [ipvs modules](https://github.com/kubernetes-sigs/kpng/blob/8a78a86a9e451a0b89fa749aa9746ff4ead4cab0/backends/ipvs/internal/ipvs/util.go#L100). 

### Which issue(s) this PR fixes?
When run locally with `ipvs` as a backend, `kpng` fail to start with error:

```
setup.go:36] unable to initialize ipvs managererror can't set sysctl net/ipv4/vs/conntrack to 1: open /proc/sys/net/ipv4/vs/conntrack: no such file or directory
```

The error occur because ipvs modules are not loaded, so there is no `/proc/sys/net/ipv4/vs` directory and the file [conntrack](https://github.com/kubernetes-sigs/kpng/blob/8a78a86a9e451a0b89fa749aa9746ff4ead4cab0/backends/ipvs/internal/ipvs/util.go#L67) cannot be created.

Fixes #

### Additional information about this PR

```sh
kind --version
kind version 0.20.0
```

Node is running `Ubuntu 22.04.2 LTS`:
```sh
cat /proc/sys/kernel/osrelease
6.2.0-26-generic
```
