### PR TITLE
Downgrade kpng alpine image to align nftables with nodes OS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ add . ./
 run go install -trimpath -buildvcs=false ./cmd/...
 
 # the real image
-from alpine:3.17
+from alpine:3.16
 entrypoint ["/bin/kpng"]
 run apk add --update iptables ip6tables iproute2 ipvsadm nftables ipset conntrack-tools
 copy --from=build /go/bin/ /bin/


### PR DESCRIPTION
### What kind of PR is this?
<!-- Add somethings like is it a Bug / Documentation / Feature -->
Hopefully a bugfix.

### Why this PR is needed / What this PR do?
This PR aligns `nftables` version in [kpng image](https://pkgs.alpinelinux.org/packages?name=nftables&branch=v3.16&repo=&arch=x86_64&maintainer=) and [os node image](https://packages.ubuntu.com/jammy/nftables).
Currently, when e2e tests run locally nft rules set up incorrectly due to the versions mismatch that results in `[invalid type]` in chains.
To reproduce 
1. start `kpng` without running tests via `./hack/test_e2e.sh -i ipv4 -b nft -d`
2. join a worker node, install `nftables` and check for `invalid type`:
```sh
kubectl node-shell kpng-e2e-ipv4-nft-worker
apt update && apt install -y nftables
nft list ruleset | grep invalid
```

`kpng` has nothing to do with that. One can reproduce it by ssh-ing to a kpng pod and applying nft rules:
```sh
vi nft.conf
table ip6 test {
        chain svc_1 {
                tcp dport 80 dnat to fd6d:706e:6701:2::2:8080
                fib daddr type local tcp dport 30202 dnat to fd6d:706e:6701:2::2:8080
        }

        chain svc_default_nodeport-test_eps {
                numgen random mod 2 vmap { 0 : jump svc_2, 1 : jump svc_1 }
        }

        chain svc_2 {
                tcp dport 80 dnat to fd6d:706e:6701:1::2:8080
                fib daddr type local tcp dport 30202 dnat to fd6d:706e:6701:1::2:8080
        }
}
nft -f nft.conf
```

On the node the new `test` table will look like:
```
table ip6 test {
        chain svc_1 {
                tcp dport 80 dnat to fd6d:706e:6701:2::2:8080
                fib daddr type local tcp dport 30202 dnat to fd6d:706e:6701:2::2:8080
        }

        chain svc_default_nodeport-test_eps {
                numgen random mod 2 map { 0 : 0x0 [invalid type], 1 : 0x1000000 [invalid type] }
        }

        chain svc_2 {
                tcp dport 80 dnat to fd6d:706e:6701:1::2:8080
                fib daddr type local tcp dport 30202 dnat to fd6d:706e:6701:1::2:8080
        }
}
```

There is no `invalid type` message when the same steps are executed from `alpine:3.16` image.

**NOTE**: I checked GH e2e action and it uses the same images (alpine 3.17 and ubuntu 22.04). When tests run locally I see invalid types during tests execution, but 335 tests run successfully so I suspect the chains with invalid types are not hit :shrug:.

Probably related to the [issue](https://github.com/kubernetes-sigs/kpng/issues/467). 

### Which issue(s) this PR fixes?

Fixes #

### Additional information about this PR

