### PR TITLE
Bump kpng alpine image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ add . ./
 run go install -trimpath -buildvcs=false ./cmd/...
 
 # the real image
-from alpine:3.16
+from alpine:3.18
 entrypoint ["/bin/kpng"]
 run apk add --update iptables ip6tables iproute2 ipvsadm nftables ipset conntrack-tools
 copy --from=build /go/bin/ /bin/


### PR DESCRIPTION
### What kind of PR is this?
This PR reverts #525 and also bumps alpine to 3.18

### Why this PR is needed / What this PR do?
Decompilation of the nft ruleset with the older nftables version might not work, but the rules themselves should work in kernel correctly. See [comment](https://github.com/kubernetes-sigs/kpng/pull/525#issuecomment-1694610205).

### Which issue(s) this PR fixes?

Fixes #

### Additional information about this PR

