### PR TITLE
Fix epslices

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/golang/protobuf v1.5.3
 	google.golang.org/grpc v1.50.0
 	google.golang.org/protobuf v1.28.1
+	k8s.io/klog/v2 v2.80.1
 )
 
 require (
+	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,3 +1,4 @@
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -15,3 +16,4 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=

--- a/api/localv1/endpoint_test.go
+++ b/api/localv1/endpoint_test.go
@@ -20,9 +20,22 @@ import "fmt"
 
 func ExampleEndpointPortMapping() {
 	ports := []*PortMapping{
+		// name doesn't match -> ignore the rest
 		{Name: "http", TargetPortName: "t-http", TargetPort: 8080},
+		// name matches -> ignore the rest
 		{Name: "http2", TargetPortName: "t-http2", TargetPort: 800},
-		{Name: "metrics", TargetPortName: "t-metrics"},
+		// name matches -> ignore the rest
+		{Name: "metrics", TargetPortName: "http2"},
+		// name matches -> ignore the rest
+		{Name: "metrics", TargetPort: 80},
+		// name matches
+		{Name: "metrics"},
+		// targetPortName matches, no name -> ignore TargetPort
+		{TargetPortName: "metrics", TargetPort: 8080},
+		// targetPortName doesn't match, no name -> ignore targetPort
+		{TargetPortName: "t-metrics", TargetPort: 8080},
+		// nothing to match -> err expected
+		{},
 	}
 
 	ep := &Endpoint{
@@ -33,11 +46,17 @@ func ExampleEndpointPortMapping() {
 	}
 
 	for _, port := range ports {
-		fmt.Println(port.Name, ep.PortMapping(port))
+		p, err := ep.PortMapping(port)
+		fmt.Println(port.Name, p, err)
 	}
 
 	// Output:
-	// http 8080
-	// http2 888
-	// metrics 1011
+	// http 0 not found http in port overrides
+	// http2 888 <nil>
+	// metrics 1011 <nil>
+	// metrics 1011 <nil>
+	// metrics 1011 <nil>
+	//  1011 <nil>
+	//  0 not found t-metrics in port overrides
+	//  0 port mapping is undefined
 }

--- a/backends/nft/endpoint.go
+++ b/backends/nft/endpoint.go
@@ -19,6 +19,7 @@ package nft
 import (
 	"encoding/hex"
 	"fmt"
+	"k8s.io/klog/v2"
 	"net/netip"
 	"strconv"
 
@@ -63,8 +64,9 @@ func (ctx *renderContext) addEndpointChain(svc *localv1.Service, epIP EpIP, svcC
 				continue
 			}
 
-			targetPort := epIP.Endpoint.PortMapping(port)
-			if targetPort == 0 {
+			targetPort, err := epIP.Endpoint.PortMapping(port)
+			if err != nil {
+				klog.V(1).InfoS("failed to map port", "err", err)
 				continue
 			}
 

--- a/backends/nft/svc-chain.go
+++ b/backends/nft/svc-chain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nft
 
 import (
+	"k8s.io/klog/v2"
 	"strconv"
 
 	localv1 "sigs.k8s.io/kpng/api/localv1"
@@ -55,7 +56,8 @@ func (ctx *renderContext) addSvcChain(svc *localv1.Service, epIPs []EpIP) {
 		// filter endpoint based on port availability
 		subset := make([]EpIP, 0, len(epIPs))
 		for _, epIP := range epIPs {
-			if epIP.Endpoint.PortMapping(port) == 0 {
+			if _, err := epIP.Endpoint.PortMapping(port); err != nil {
+				klog.V(1).InfoS("failed to map port", "err", err)
 				continue
 			}
 			subset = append(subset, epIP)

--- a/client/plugins/conntrack/conntrack.go
+++ b/client/plugins/conntrack/conntrack.go
@@ -90,14 +90,15 @@ func (ct Conntrack) Callback(ch <-chan *client.ServiceEndpoints) {
 
 				for _, ep := range seps.Endpoints {
 					for _, epIP := range ep.IPs.All() {
+						p, err := ep.PortMapping(svcPort)
+						if err != nil {
+							klog.V(1).InfoS("failed to map port", "err", err)
+							continue
+						}
 						flow := Flow{
 							IPPort:     ipp,
 							EndpointIP: epIP,
-							TargetPort: ep.PortMapping(svcPort),
-						}
-
-						if flow.TargetPort == 0 {
-							continue // no target port found
+							TargetPort: p,
 						}
 
 						ct.flows.Get(flow.Key()).Set(flow)

--- a/client/plugins/conntrack/sink.go
+++ b/client/plugins/conntrack/sink.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conntrack
 
 import (
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/kpng/api/localv1"
 	"sigs.k8s.io/kpng/client/localsink"
 )
@@ -89,7 +90,12 @@ func (ps *Sink) DeleteEndpoint(namespace, serviceName, key string) {
 			for _, epIP := range ep.IPs.All() {
 				targetPort = port.Port
 				if port.Port == 0 {
-					targetPort = int32(ep.PortMapping(port))
+					p, err := ep.PortMapping(port)
+					if err != nil {
+						klog.V(1).InfoS("failed to map port", "err", err)
+						continue
+					}
+					targetPort = p
 				}
 				flow := Flow{
 					IPPort:     IPPort{Protocol: port.Protocol, DnatIP: svcIP, Port: targetPort},

--- a/server/jobs/kube2store/slice-event-handler.go
+++ b/server/jobs/kube2store/slice-event-handler.go
@@ -55,7 +55,6 @@ func (h sliceEventHandler) OnAdd(obj interface{}) {
 			ServiceName: serviceName,
 			SourceName:  eps.Name,
 			Endpoint:    &localv1.Endpoint{},
-			Conditions:  &globalv1.EndpointConditions{},
 			Topology:    &globalv1.TopologyInfo{},
 		}
 
@@ -85,8 +84,8 @@ func (h sliceEventHandler) OnAdd(obj interface{}) {
 			sort.Strings(info.Hints.Zones) // stable zone order
 		}
 
-		if r := sliceEndpoint.Conditions.Ready; r != nil && *r {
-			info.Conditions.Ready = true
+		if r := sliceEndpoint.Conditions.Ready; r != nil {
+			info.Conditions = &globalv1.EndpointConditions{Ready: *r}
 		}
 
 		for _, addr := range sliceEndpoint.Addresses {

--- a/server/pkg/endpoints/node.go
+++ b/server/pkg/endpoints/node.go
@@ -47,7 +47,7 @@ func ForNode(tx *proxystore.Tx, si *globalv1.ServiceInfo, nodeName string) (endp
 
 		info.Endpoint.Local = info.Topology.Node == nodeName
 
-		if !info.Conditions.Ready {
+		if info.Conditions != nil && !info.Conditions.Ready {
 			return
 		}
 


### PR DESCRIPTION
### What kind of PR is this?
<!-- Add somethings like is it a Bug / Documentation / Feature -->
Bugfix

### Why this PR is needed / What this PR do?
<!-- Explain in brief about what you have changed and how it is helpful.-->
First commit addresses a situation when an endpoint slice is not ready, but it was not set.
Second commit complements #520 (which can be closed in favor of this PR). The [port mapping](https://github.com/kubernetes-sigs/kpng/commit/6ec42e7b6ce414092d406ea1c9bc75bd849cea75#diff-797a7515d4f869cd70ff1e72a62fab4fd348ad3b509f9a815dbe45ffcbcb3638R34) should be done based on field precedence: 1. `port.Name`; 2. `port.TargetPortName`; 3. `port.TargetPort` (see the [adjusted test](https://github.com/kubernetes-sigs/kpng/commit/6ec42e7b6ce414092d406ea1c9bc75bd849cea75#diff-6979f344dc49b8ed56f05d876a188b024bbf09e14ebb5131323950208bae9a8fR54)).


### Which issue(s) this PR fixes?

Fixes #
Following tests pass:
- `EndpointSlice [It] should support a Service with multiple ports specified in multiple EndpointSlices`
- `EndpointSlice [It] should support a Service with multiple endpoint IPs specified in multiple EndpointSlices`
- `EndpointSliceMirroring [It] should mirror a custom Endpoint with multiple subsets and same IP address`

### Additional information about this PR

